### PR TITLE
Parse "conjur-map" with encoding/json instead of strings.split

### DIFF
--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -47,7 +47,7 @@ const CSPFK026E string = "CSPFK026E Data entry map cannot be empty"
 const CSPFK027E string = "CSPFK027E Failed to update K8s secrets map with Conjur secrets"
 const CSPFK028E string = "CSPFK028E Failed to find any k8s secrets defined with a '%s’ data entry"
 const CSPFK029E string = "CSPFK029E k8s secret '%s' has no value defined for the '%s' data entry"
-const CSPFK030E string = "CSPFK030E k8s secret '%s' has an invalid value for '%s' data entry"
+const CSPFK030E string = "CSPFK030E k8s secret '%s' has an invalid value for '%s' data entry. Reason: %s"
 
 // Conjur
 const CSPFK031E string = "CSPFK031E Failed to load Conjur config. Reason: %s"


### PR DESCRIPTION
The input for `conjur-map` is practically a json object so it's best
to unmarshal it into a Json object rather than parsing it by
ourselves with splitting by `:` and `\n`