### PR TITLE
Remove all white spaces from list "K8S_SECRETS" list

### DIFF
--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -39,7 +39,7 @@ func NewFromEnv() (*Config, error) {
 	podNamespace := os.Getenv("MY_POD_NAMESPACE")
 
 	// Remove all white spaces from list
-	k8sSecretsList := strings.Replace(os.Getenv("K8S_SECRETS"), " ", "", -1)
+	k8sSecretsList := strings.ReplaceAll(os.Getenv("K8S_SECRETS"), " ", "")
 	// Split the comma-separated list into an array
 	requiredK8sSecrets := strings.Split(k8sSecretsList, ",")
 


### PR DESCRIPTION
i tried to challenge the way we reading the "K8S_SECRETS" list, i didn't find a better UX from the current:
```
          - name: K8S_SECRETS
            value:  db-credentials,   test-secrets
```
i added a small improvement of deleting the white spaces from the list