### PR TITLE
Add option to run OSS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,15 @@ pipeline {
       }
     }
 
-    stage('Run Integrations Tests') {
+    stage('Run Integrations Tests - OSS') {
       steps {
         sh './bin/test_integration --docker'
+      }
+    }
+
+    stage('Run Integrations Tests - DAP') {
+      steps {
+        sh './bin/test_integration --docker --dap'
       }
     }
 

--- a/bin/test_integration
+++ b/bin/test_integration
@@ -7,12 +7,14 @@ container and a cyberark-secrets-provider-for-k8s init container. Finally it tes
 in the vanilla flow it verifies that the Conjur secret was provided to the app container via the environment.
 
 Usage: ./bin/test_integation [options]
-    --docker      Run the integation test in a docker container. This is helpful when running the test in a machine that
+    --docker      Run the integation tests in a docker container. This is helpful when running the test in a machine that
                   doesn't have "oc" or "kubectl" installed on it.
 
     --demo        Run a full end-to-end demo with the pet-store demo. This demo deploys an environment with an app container
                   that needs credentials to a DB from Conjur. After running "./bin/test_integation --demo" run "oc get routes"
                   and go to "<the exposed route>/pets" in a browser. The entry "Mr. Sidecar" should be displayed on the screen.
+
+    --dap         Run the integation tests with a DAP Conjur deployment. By default the tests are run against a Conjur OSS deployment
 
     -h, --help    Shows this help message.
 EOF
@@ -25,14 +27,18 @@ function runScriptWithSummon() {
 
 RUN_IN_DOCKER=false
 DEMO=false
+CONJUR_DEPLOYMENT=oss
 while true ; do
   case "$1" in
     --docker ) RUN_IN_DOCKER=true ; shift ;;
     --demo ) DEMO=true ; shift ;;
+    --dap ) CONJUR_DEPLOYMENT=dap ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac
 done
+
+export CONJUR_DEPLOYMENT
 
 source test/bootstrap.env
 

--- a/test/4_init_conjur_cert_authority.sh
+++ b/test/4_init_conjur_cert_authority.sh
@@ -9,6 +9,10 @@ set_namespace $CONJUR_NAMESPACE_NAME
 
 conjur_master=$(get_master_pod_name)
 
-$cli exec $conjur_master -- chpst -u conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
+cmd='rake authn_k8s:ca_init['"conjur/authn-k8s/$AUTHENTICATOR_ID"]
+if [ "$CONJUR_DEPLOYMENT" = "dap" ]; then
+  cmd='chpst -u conjur conjur-plugin-service possum '"$cmd"
+fi
+$cli exec $conjur_master -- $cmd
 
 echo "Certificate authority initialized."

--- a/test/bootstrap.env
+++ b/test/bootstrap.env
@@ -1,15 +1,14 @@
 export UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)"
 export CONJUR_VERSION=5
 export CONJUR_MINOR_VERSION=5.0
-export CONJUR_APPLIANCE_IMAGE=registry.tld/conjur-appliance:$CONJUR_VERSION.$CONJUR_MINOR_VERSION
+export CONJUR_APPLIANCE_IMAGE=registry.tld/conjur-appliance:$CONJUR_MINOR_VERSION-stable
 export CONJUR_FOLLOWER_COUNT=1
 export CONJUR_ACCOUNT=account-$UNIQUE_TEST_ID
 export AUTHENTICATOR_ID=conjur-$CONJUR_VERSION-$UNIQUE_TEST_ID-test
-export CONJUR_ADMIN_PASSWORD=adminPass$UNIQUE_TEST_ID
+export CONJUR_ADMIN_PASSWORD=secret
 export DEPLOY_MASTER_CLUSTER=true
-export CONJUR_NAMESPACE_NAME=conjur-deploy-$UNIQUE_TEST_ID
+export CONJUR_NAMESPACE_NAME=conjur-$CONJUR_VERSION-$UNIQUE_TEST_ID-test
 export TEST_RUNNER_IMAGE=demo-$UNIQUE_TEST_ID
-export KUBERNETES_CONJUR_DEPLOY_BRANCH=v0.1
 
 #######
 # OpenShift
@@ -21,8 +20,7 @@ export PLATFORM=openshift
 # Test App
 #######
 
-export LOCAL_AUTHENTICATOR=true
-export TEST_APP_NAMESPACE_NAME=test-app-$UNIQUE_TEST_ID
+export TEST_APP_NAMESPACE_NAME=test-app-$CONJUR_VERSION-$UNIQUE_TEST_ID
 
 export MINIKUBE="${MINIKUBE:-false}"
 export MINISHIFT="${MINISHIFT:-false}"

--- a/test/k8s-config/test-env.sh.yml
+++ b/test/k8s-config/test-env.sh.yml
@@ -65,12 +65,10 @@ spec:
             value: '5'
 
           - name: CONJUR_APPLIANCE_URL
-            value: >-
-              https://conjur-follower.${CONJUR_NAMESPACE_NAME}.svc.cluster.local/api
+            value: ${CONJUR_APPLIANCE_URL}
 
           - name: CONJUR_AUTHN_URL
-            value: >-
-              https://conjur-follower.${CONJUR_NAMESPACE_NAME}.svc.cluster.local/api/authn-k8s/${AUTHENTICATOR_ID}
+            value: ${CONJUR_AUTHN_URL}
 
           - name: CONJUR_ACCOUNT
             value: ${CONJUR_ACCOUNT}
@@ -84,6 +82,7 @@ spec:
               configMapKeyRef:
                 name: conjur-master-ca-env
                 key: ssl-certificate
+
           - name: DEBUG
             value: "true"
 

--- a/test/policy/load_policies.sh
+++ b/test/policy/load_policies.sh
@@ -2,12 +2,14 @@
 set -eo pipefail
 
 if [ "$CONJUR_APPLIANCE_URL" != "" ]; then
+  echo "Running conjur init with $CONJUR_APPLIANCE_URL"
   conjur init -u $CONJUR_APPLIANCE_URL -a $CONJUR_ACCOUNT
 fi
 
 # check for unset vars after checking for appliance url
 set -u
 
+echo "Login to Conjur with the conjur-cli"
 conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
 
 readonly POLICY_DIR="/policy"

--- a/test/summon/secrets.yml
+++ b/test/summon/secrets.yml
@@ -7,7 +7,7 @@ common:
   POSTGRES_PASSWORD: !var qa/xa/p2p/postgresql/password
 
 openshift:
-  DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
   OPENSHIFT_URL: !var ci/openshift/3.11/hostname
   OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
   OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
+  DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url

--- a/test/test_in_docker.sh
+++ b/test/test_in_docker.sh
@@ -19,10 +19,8 @@ function buildTestRunnerImage() {
 
 function deployConjur() {
   pushd ..
-    # TODO: change to master/v0.1 once deploy-oss is merged
-    # taking v0.1 since latest kubernetes-conjur-deploy is not stable
     git clone --single-branch \
-      --branch deploy-oss \
+      --branch master \
       git@github.com:cyberark/kubernetes-conjur-deploy \
       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd

--- a/test/test_in_docker.sh
+++ b/test/test_in_docker.sh
@@ -19,14 +19,19 @@ function buildTestRunnerImage() {
 
 function deployConjur() {
   pushd ..
+    # TODO: change to master/v0.1 once deploy-oss is merged
     # taking v0.1 since latest kubernetes-conjur-deploy is not stable
     git clone --single-branch \
-      --branch $KUBERNETES_CONJUR_DEPLOY_BRANCH \
-      https://github.com/cyberark/kubernetes-conjur-deploy.git \
+      --branch deploy-oss \
+      git@github.com:cyberark/kubernetes-conjur-deploy \
       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd
 
-  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./start"
+  cmd="./start"
+  if [ $CONJUR_DEPLOYMENT == "dap" ]; then
+      cmd="$cmd --dap"
+  fi
+  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && $cmd"
 }
 
 function deployTest() {

--- a/test/test_local.sh
+++ b/test/test_local.sh
@@ -11,8 +11,7 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    # TODO: change to master/v0.1 once it is merged
-    git clone --single-branch --branch deploy-oss git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
     cmd="./start"
     if [ $CONJUR_DEPLOYMENT == "dap" ]; then

--- a/test/test_local.sh
+++ b/test/test_local.sh
@@ -11,15 +11,14 @@ function main() {
 
 function deployConjur() {
   pushd ..
-     # taking v0.1 since latest kubernetes-conjur-deploy is not stable
-    git clone --single-branch \
-       --branch $KUBERNETES_CONJUR_DEPLOY_BRANCH \
-       https://github.com/cyberark/kubernetes-conjur-deploy.git \
-       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    # TODO: change to master/v0.1 once it is merged
+    git clone --single-branch --branch deploy-oss git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
-    pushd kubernetes-conjur-deploy-$UNIQUE_TEST_ID
-      ./start
-    popd
+    cmd="./start"
+    if [ $CONJUR_DEPLOYMENT == "dap" ]; then
+        cmd="$cmd --dap"
+    fi
+    cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && $cmd
   popd
 }
 

--- a/test/test_with_summon.sh
+++ b/test/test_with_summon.sh
@@ -25,13 +25,19 @@ docker push "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider
 
 readonly K8S_CONFIG_DIR="k8s-config"
 
-# this variable is consumed in test-env.sh.yml
-conjur_node_pod=$($cli get pod --namespace $CONJUR_NAMESPACE_NAME \
-                      --selector=app=conjur-node \
-                      -o=jsonpath='{.items[].metadata.name}')
-export CONJUR_SSL_CERTIFICATE=$($cli exec --namespace $CONJUR_NAMESPACE_NAME \
-                                 "${conjur_node_pod}" \
-                                  cat /opt/conjur/etc/ssl/conjur.pem)
+selector="role=follower"
+cert_location="/opt/conjur/etc/ssl/conjur.pem"
+if [ "$CONJUR_DEPLOYMENT" = "oss" ]; then
+    selector="app=conjur-cli"
+    cert_location="/root/conjur-${CONJUR_ACCOUNT}.pem"
+fi
+conjur_pod_name=$(oc get pods \
+                      --selector=$selector \
+                      --namespace $CONJUR_NAMESPACE_NAME \
+                      --no-headers | awk '{ print $1 }' | head -1)
+ssl_cert=$(oc exec "${conjur_pod_name}" --namespace $CONJUR_NAMESPACE_NAME cat $cert_location)
+
+export CONJUR_SSL_CERTIFICATE=$ssl_cert
 
 pushd test_cases > /dev/null
   ./run_tests.sh


### PR DESCRIPTION
This PR allows users to switch between OSS and DAP environments and validates testing with OSS.

Once PR https://github.com/cyberark/kubernetes-conjur-deploy/pull/84 is merged we should change the repo clone from the side-branch to master.