### PR TITLE
Find and remove `cyberark` prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN go get -u github.com/jstemmer/go-junit-report && \
 ENV GOOS=linux
 ENV GOARCH=amd64
 
-WORKDIR /opt/cyberark-secrets-provider-for-k8s
+WORKDIR /opt/secrets-provider-for-k8s
 EXPOSE 8080

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,6 +1,6 @@
 FROM golang:1.12.0-alpine3.9
 MAINTAINER Conjur Inc.
-LABEL id="cyberark-secrets-provider-for-k8s-junit-processor"
+LABEL id="secrets-provider-for-k8s-junit-processor"
 
 WORKDIR /test
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,8 @@
 FROM golang:1.12.0-alpine3.9
 MAINTAINER Conjur Inc.
-LABEL id="cyberark-secrets-provider-for-k8s-test-runner"
+LABEL id="secrets-provider-for-k8s-test-runner"
 
-WORKDIR /cyberark-secrets-provider-for-k8s
+WORKDIR /secrets-provider-for-k8s
 
 RUN apk add -u curl \
                gcc \
@@ -10,7 +10,7 @@ RUN apk add -u curl \
                mercurial \
                musl-dev
 
-COPY go.mod go.sum /cyberark-secrets-provider-for-k8s/
+COPY go.mod go.sum /secrets-provider-for-k8s/
 
 RUN go mod download
 

--- a/bin/build
+++ b/bin/build
@@ -11,18 +11,18 @@ function finish {
 }
 trap finish EXIT
 
-docker build --tag cyberark-secrets-provider-for-k8s-go:builder .
+docker build --tag secrets-provider-for-k8s-go:builder .
 
 docker run --rm \
-           -v $PWD:/opt/cyberark-secrets-provider-for-k8s \
-           cyberark-secrets-provider-for-k8s-go:builder env CGO_ENABLED=0 GOOS=linux \
+           -v $PWD:/opt/secrets-provider-for-k8s \
+           secrets-provider-for-k8s-go:builder env CGO_ENABLED=0 GOOS=linux \
                                               go build -a -installsuffix cgo -o secrets-provider ./cmd/secrets-provider
 
-echo "Building cyberark-secrets-provider-for-k8s:$FULL_VERSION_TAG Docker image"
+echo "Building secrets-provider-for-k8s:$FULL_VERSION_TAG Docker image"
 docker build -f Dockerfile.scratch \
-             --tag "cyberark-secrets-provider-for-k8s:dev" \
-             --tag "cyberark-secrets-provider-for-k8s:${FULL_VERSION_TAG}" \
-             --tag "cyberark-secrets-provider-for-k8s:latest" \
+             --tag "secrets-provider-for-k8s:dev" \
+             --tag "secrets-provider-for-k8s:${FULL_VERSION_TAG}" \
+             --tag "secrets-provider-for-k8s:latest" \
              .
 
 echo "---"

--- a/bin/publish
+++ b/bin/publish
@@ -17,7 +17,7 @@ readonly TAGS=(
   "latest"
 )
 
-readonly IMAGE_NAME="cyberark-secrets-provider-for-k8s"
+readonly IMAGE_NAME="secrets-provider-for-k8s"
 
 # always push the tag with the commit hash to internal registry
 echo "Tagging $INTERNAL_REGISTRY/$IMAGE_NAME:${FULL_VERSION_TAG}"

--- a/bin/test_integration
+++ b/bin/test_integration
@@ -2,8 +2,8 @@
 
 function print_help() {
   cat << EOF
-Test the cyberark-secrets-provider-for-k8s image. This script sets up a Conjur cluster in k8s and deploys a k8s environment with an app
-container and a cyberark-secrets-provider-for-k8s init container. Finally it tests that the outcome is as expected (for example,
+Test the secrets-provider-for-k8s image. This script sets up a Conjur cluster in k8s and deploys a k8s environment with an app
+container and a secrets-provider-for-k8s init container. Finally it tests that the outcome is as expected (for example,
 in the vanilla flow it verifies that the Conjur secret was provided to the app container via the environment.
 
 Usage: ./bin/test_integation [options]

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -11,11 +11,11 @@ rm -f "$junit_output_file"
 touch "$junit_output_file"
 
 echo "Building unit test image..."
-docker build -f Dockerfile.test -t cyberark-secrets-provider-for-k8s-test-runner:latest .
+docker build -f Dockerfile.test -t secrets-provider-for-k8s-test-runner:latest .
 
 echo "Running unit tests..."
 set +e
-  docker run --rm -t cyberark-secrets-provider-for-k8s-test-runner:latest \
+  docker run --rm -t secrets-provider-for-k8s-test-runner:latest \
              ./cmd/... \
              ./pkg/... \
              | tee -a "$junit_output_file"
@@ -26,13 +26,13 @@ rm -f junit.xml
 
 echo "Building junit image..."
 
-docker build -f Dockerfile.junit -t cyberark-secrets-provider-for-k8s-junit:latest .
+docker build -f Dockerfile.junit -t secrets-provider-for-k8s-junit:latest .
 
 echo "Creating junit report..."
 
 docker run --rm \
   -v $PWD/unit-test:/test \
-  cyberark-secrets-provider-for-k8s-junit:latest \
+  secrets-provider-for-k8s-junit:latest \
   bash -exc "
     cat ./junit.output | go-junit-report > ./junit.xml
   "

--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -10,10 +10,10 @@ import (
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator"
 	authnConfigProvider "github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator/config"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets"
-	secretsConfigProvider "github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/config"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets"
+	secretsConfigProvider "github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/config"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cyberark/cyberark-secrets-provider-for-k8s
+module github.com/cyberark/secrets-provider-for-k8s
 
 go 1.12
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 var stdoutLogger = log.New(os.Stdout, "INFO:  ", log.LUTC|log.Ldate|log.Ltime|log.Lshortfile)

--- a/pkg/secrets/clients/conjur/conjur_client.go
+++ b/pkg/secrets/clients/conjur/conjur_client.go
@@ -3,8 +3,8 @@ package conjur
 import (
 	"github.com/cyberark/conjur-api-go/conjurapi"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 /*

--- a/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
+++ b/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
@@ -1,8 +1,8 @@
 package conjur
 
 import (
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 type RetrieveConjurSecretsFunc func(accessToken []byte, variableIDs []string) (map[string][]byte, error)

--- a/pkg/secrets/clients/k8s/k8s_secrets_client.go
+++ b/pkg/secrets/clients/k8s/k8s_secrets_client.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/utils"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/utils"
 )
 
 type RetrieveK8sSecretFunc func(namespace string, secretName string) (map[string][]byte, error)

--- a/pkg/secrets/clients/k8s/k8s_secrets_client_test.go
+++ b/pkg/secrets/clients/k8s/k8s_secrets_client_test.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 func TestKubernetesSecrets(t *testing.T) {

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 const (

--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
 func TestConfig(t *testing.T) {

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
@@ -7,11 +7,11 @@ import (
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/access_token"
 	"gopkg.in/yaml.v2"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/clients/conjur"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/clients/k8s"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/config"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/clients/conjur"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/clients/k8s"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/config"
 )
 
 type K8sSecretsMap struct {

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
@@ -8,8 +8,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/log/messages"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/k8s_secrets_storage/mocks"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/k8s_secrets_storage/mocks"
 )
 
 func TestProvideConjurSecrets(t *testing.T) {

--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -3,8 +3,8 @@ package secrets
 import (
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/access_token"
 
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/config"
-	"github.com/cyberark/cyberark-secrets-provider-for-k8s/pkg/secrets/k8s_secrets_storage"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/config"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/k8s_secrets_storage"
 )
 
 type ProvideConjurSecrets func(AccessToken access_token.AccessToken) error

--- a/test/run_demo.sh
+++ b/test/run_demo.sh
@@ -21,7 +21,7 @@ function main() {
     ./4_init_conjur_cert_authority.sh
   fi
 
-  docker tag "cyberark-secrets-provider-for-k8s:dev" "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider"
+  docker tag "secrets-provider-for-k8s:dev" "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider"
   docker push "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider"
 
   set_namespace $TEST_APP_NAMESPACE_NAME

--- a/test/test_with_summon.sh
+++ b/test/test_with_summon.sh
@@ -19,7 +19,7 @@ fi
 set_namespace $TEST_APP_NAMESPACE_NAME
 
 echo "Publish docker image"
-docker tag "cyberark-secrets-provider-for-k8s:dev" \
+docker tag "secrets-provider-for-k8s:dev" \
          "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider"
 docker push "${DOCKER_REGISTRY_PATH}/${TEST_APP_NAMESPACE_NAME}/secrets-provider"
 


### PR DESCRIPTION
This PR change goes through the code and repo and updates all the places where `cyberark-secrets-provider-for-k8s` exists and replaces it with `secrets-provider-for-k8s`

Connected with #31 