### PR TITLE
Use tag of kubernetes-conjur-deploy for deploying OSS by default

### DIFF
--- a/test/run_demo.sh
+++ b/test/run_demo.sh
@@ -55,7 +55,7 @@ function CreatePetStoreApp() {
 
 function deployConjur() {
   pushd ..
-    git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch deploy-oss-by-default git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
     pushd kubernetes-conjur-deploy-$UNIQUE_TEST_ID
       ./start

--- a/test/test_in_docker.sh
+++ b/test/test_in_docker.sh
@@ -20,7 +20,7 @@ function buildTestRunnerImage() {
 function deployConjur() {
   pushd ..
     git clone --single-branch \
-      --branch master \
+      --branch deploy-oss-by-default \
       git@github.com:cyberark/kubernetes-conjur-deploy \
       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd

--- a/test/test_local.sh
+++ b/test/test_local.sh
@@ -11,7 +11,7 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch deploy-oss-by-default git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
     cmd="./start"
     if [ $CONJUR_DEPLOYMENT == "dap" ]; then


### PR DESCRIPTION
Until we fix kubernetes-conjur-deploy to have both OSS & DAP properly we will use a tag of that repo that has this functionality. 