### PR TITLE
Add additional tests

### DIFF
--- a/test/config/k8s/test-env.sh.yml
+++ b/test/config/k8s/test-env.sh.yml
@@ -9,6 +9,7 @@ set -euo pipefail
 SECRETS_DESTINATION_KEY_VALUE=${SECRETS_DESTINATION_KEY_VALUE:-"SECRETS_DESTINATION k8s_secrets"}
 CONTAINER_MODE_KEY_VALUE=${CONTAINER_MODE_KEY_VALUE:-"CONTAINER_MODE init"}
 K8S_SECRETS_KEY_VALUE=${K8S_SECRETS_KEY_VALUE:-"K8S_SECRETS test-k8s-secret"}
+CONJUR_AUTHN_LOGIN_KEY_VALUE=${CONJUR_AUTHN_LOGIN_KEY_VALUE:-"CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
 
 cat << EOL
 ---
@@ -74,10 +75,6 @@ spec:
           - name: CONJUR_ACCOUNT
             value: ${CONJUR_ACCOUNT}
 
-          - name: CONJUR_AUTHN_LOGIN
-            value: >-
-              host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*
-
           - name: CONJUR_SSL_CERTIFICATE
             valueFrom:
               configMapKeyRef:
@@ -90,6 +87,7 @@ spec:
 `yaml_print_key_name_value "          " ${K8S_SECRETS_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${CONTAINER_MODE_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${SECRETS_DESTINATION_KEY_VALUE}`
+`yaml_print_key_name_value "          " ${CONJUR_AUTHN_LOGIN_KEY_VALUE}`
 
       imagePullSecrets:
         - name: dockerpullsecret

--- a/test/config/k8s/test-env.sh.yml
+++ b/test/config/k8s/test-env.sh.yml
@@ -9,7 +9,7 @@ set -euo pipefail
 SECRETS_DESTINATION_KEY_VALUE=${SECRETS_DESTINATION_KEY_VALUE:-"SECRETS_DESTINATION k8s_secrets"}
 CONTAINER_MODE_KEY_VALUE=${CONTAINER_MODE_KEY_VALUE:-"CONTAINER_MODE init"}
 K8S_SECRETS_KEY_VALUE=${K8S_SECRETS_KEY_VALUE:-"K8S_SECRETS test-k8s-secret"}
-CONJUR_AUTHN_LOGIN_KEY_VALUE=${CONJUR_AUTHN_LOGIN_KEY_VALUE:-"CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
+CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
 
 cat << EOL
 ---
@@ -84,10 +84,12 @@ spec:
           - name: DEBUG
             value: "true"
 
+          - name: CONJUR_AUTHN_LOGIN
+            value: ${CONJUR_AUTHN_LOGIN}
+
 `yaml_print_key_name_value "          " ${K8S_SECRETS_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${CONTAINER_MODE_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${SECRETS_DESTINATION_KEY_VALUE}`
-`yaml_print_key_name_value "          " ${CONJUR_AUTHN_LOGIN_KEY_VALUE}`
 
       imagePullSecrets:
         - name: dockerpullsecret

--- a/test/config/openshift/test-env.sh.yml
+++ b/test/config/openshift/test-env.sh.yml
@@ -9,7 +9,7 @@ set -euo pipefail
 SECRETS_DESTINATION_KEY_VALUE=${SECRETS_DESTINATION_KEY_VALUE:-"SECRETS_DESTINATION k8s_secrets"}
 CONTAINER_MODE_KEY_VALUE=${CONTAINER_MODE_KEY_VALUE:-"CONTAINER_MODE init"}
 K8S_SECRETS_KEY_VALUE=${K8S_SECRETS_KEY_VALUE:-"K8S_SECRETS test-k8s-secret"}
-CONJUR_AUTHN_LOGIN_KEY_VALUE=${CONJUR_AUTHN_LOGIN_KEY_VALUE:-"CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
+CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
 
 cat << EOL
 ---
@@ -83,10 +83,12 @@ spec:
           - name: DEBUG
             value: "true"
 
+          - name: CONJUR_AUTHN_LOGIN
+            value: ${CONJUR_AUTHN_LOGIN}
+
 `yaml_print_key_name_value "          " ${K8S_SECRETS_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${CONTAINER_MODE_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${SECRETS_DESTINATION_KEY_VALUE}`
-`yaml_print_key_name_value "          " ${CONJUR_AUTHN_LOGIN_KEY_VALUE}`
 
       imagePullSecrets:
         - name: dockerpullsecret

--- a/test/config/openshift/test-env.sh.yml
+++ b/test/config/openshift/test-env.sh.yml
@@ -9,6 +9,7 @@ set -euo pipefail
 SECRETS_DESTINATION_KEY_VALUE=${SECRETS_DESTINATION_KEY_VALUE:-"SECRETS_DESTINATION k8s_secrets"}
 CONTAINER_MODE_KEY_VALUE=${CONTAINER_MODE_KEY_VALUE:-"CONTAINER_MODE init"}
 K8S_SECRETS_KEY_VALUE=${K8S_SECRETS_KEY_VALUE:-"K8S_SECRETS test-k8s-secret"}
+CONJUR_AUTHN_LOGIN_KEY_VALUE=${CONJUR_AUTHN_LOGIN_KEY_VALUE:-"CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*"}
 
 cat << EOL
 ---
@@ -73,10 +74,6 @@ spec:
           - name: CONJUR_ACCOUNT
             value: ${CONJUR_ACCOUNT}
 
-          - name: CONJUR_AUTHN_LOGIN
-            value: >-
-              host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/*/*
-
           - name: CONJUR_SSL_CERTIFICATE
             valueFrom:
               configMapKeyRef:
@@ -89,6 +86,7 @@ spec:
 `yaml_print_key_name_value "          " ${K8S_SECRETS_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${CONTAINER_MODE_KEY_VALUE}`
 `yaml_print_key_name_value "          " ${SECRETS_DESTINATION_KEY_VALUE}`
+`yaml_print_key_name_value "          " ${CONJUR_AUTHN_LOGIN_KEY_VALUE}`
 
       imagePullSecrets:
         - name: dockerpullsecret

--- a/test/policy/templates/project-authn-def.template.sh.yml
+++ b/test/policy/templates/project-authn-def.template.sh.yml
@@ -20,6 +20,13 @@ cat << EOL
         kubernetes/authentication-container-name: cyberark-secrets-provider
         openshift: "true"
 
+    # this host will not have permissions on Conjur secrets to test this use-case
+    - !host
+      id: ${TEST_APP_NAMESPACE_NAME}/service_account/${TEST_APP_NAMESPACE_NAME}-sa
+      annotations:
+        kubernetes/authentication-container-name: cyberark-secrets-provider
+        openshift: "true"
+
   - !grant
     role: !layer
     members: *hosts

--- a/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+create_secret_access_role
+
+create_secret_access_role_binding
+
+export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/some-policy/non-existing-namespace/*/*"
+
+deploy_test_env
+
+echo "Expecting secrets provider to fail with error CAKC015E Login failed"
+pod_name=$(cli_get_pods_test_env | awk '{print $1}')
+wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CAKC015E'"

--- a/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -5,7 +5,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/some-policy/non-existing-namespace/*/*"
+export CONJUR_AUTHN_LOGIN="host/some-policy/non-existing-namespace/*/*"
 
 deploy_test_env
 

--- a/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -5,7 +5,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/service_account/${TEST_APP_NAMESPACE_NAME}-sa"
+export CONJUR_AUTHN_LOGIN="host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/service_account/${TEST_APP_NAMESPACE_NAME}-sa"
 
 deploy_test_env
 

--- a/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+create_secret_access_role
+
+create_secret_access_role_binding
+
+export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${TEST_APP_NAMESPACE_NAME}/service_account/${TEST_APP_NAMESPACE_NAME}-sa"
+
+deploy_test_env
+
+echo "Expecting secrets provider to fail with error CSPFK034E Failed to retrieve Conjur secrets"
+pod_name=$(cli_get_pods_test_env | awk '{print $1}')
+wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK034E'"


### PR DESCRIPTION
This PR adds tests for the following cases:
- Conjur authentication failure fails the pod and logs accordingly
- Conjur secrets retrieval failure fails the pod and logs accordingly