### PR TITLE
Remove `openshift` annotation from conjur hosts in the policy

### DIFF
--- a/test/policy/templates/project-authn-def.template.sh.yml
+++ b/test/policy/templates/project-authn-def.template.sh.yml
@@ -18,14 +18,12 @@ cat << EOL
       id: ${TEST_APP_NAMESPACE_NAME}/*/*
       annotations:
         kubernetes/authentication-container-name: cyberark-secrets-provider
-        openshift: "true"
 
     # this host will not have permissions on Conjur secrets to test this use-case
     - !host
       id: ${TEST_APP_NAMESPACE_NAME}/service_account/${TEST_APP_NAMESPACE_NAME}-sa
       annotations:
         kubernetes/authentication-container-name: cyberark-secrets-provider
-        openshift: "true"
 
   - !grant
     role: !layer


### PR DESCRIPTION
The `openshift: true` & `kubernetes: true` annotations enable a feature
in the UI where if this annotation exists the UI displays a logo for
the host.

We don't use this feature in this repo and because we load the same
policies for kubernetes & openshift it may be misleading for someone
who goes over the policy files.