### PR TITLE
Test authentication with application identity in host annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyberark/conjur-api-go v0.6.0
-	github.com/cyberark/conjur-authn-k8s-client v0.15.0
+	github.com/cyberark/conjur-authn-k8s-client v0.16.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cyberark/conjur-api-go v0.6.0 h1:QQYmFRhcCvmtZ9oSRoXCxWb7uRjppfu5lcEwo4HEjtg=
 github.com/cyberark/conjur-api-go v0.6.0/go.mod h1:uM96pLpckwYYAWRSbrsw+TT0y3kg49QCEGpdpa9dJ34=
-github.com/cyberark/conjur-authn-k8s-client v0.15.0 h1:HFSkyKtaWkxhOc+Whh2CV3x1HWsYWXu8yR4w6RS3umw=
-github.com/cyberark/conjur-authn-k8s-client v0.15.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
+github.com/cyberark/conjur-authn-k8s-client v0.16.0 h1:qQEpaa3Yq+wao0tj+mk6jMG/XX6sM8cOyzq3GBQplPg=
+github.com/cyberark/conjur-authn-k8s-client v0.16.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/test/policy/templates/authn-any-policy-branch.template.sh.yml
+++ b/test/policy/templates/authn-any-policy-branch.template.sh.yml
@@ -6,7 +6,7 @@
 set -euo pipefail
 cat << EOL
 ---
-# Define a policy and add a host to it
+# Define a policy and add hosts to it
 - !policy
   id: some-apps
   owner: !group devops
@@ -21,6 +21,13 @@ cat << EOL
       id: ${TEST_APP_NAMESPACE_NAME}/*/*
       annotations:
         kubernetes/authentication-container-name: cyberark-secrets-provider
+
+    # This host tests the ability to authenticate hosts with application identity in annotations
+    - !host
+      id: annotations-app
+      annotations:
+        authn-k8s/namespace: ${TEST_APP_NAMESPACE_NAME}
+        authn-k8s/authentication-container-name: cyberark-secrets-provider
 
   - !grant
     role: !layer

--- a/test/test_cases/TEST_ID_13_host_not_in_apps.sh
+++ b/test/test_cases/TEST_ID_13_host_not_in_apps.sh
@@ -5,7 +5,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/some-apps/${TEST_APP_NAMESPACE_NAME}/*/*"
+export CONJUR_AUTHN_LOGIN="host/some-apps/${TEST_APP_NAMESPACE_NAME}/*/*"
 
 deploy_test_env
 

--- a/test/test_cases/TEST_ID_14_host_in_root_policy.sh
+++ b/test/test_cases/TEST_ID_14_host_in_root_policy.sh
@@ -5,7 +5,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/${TEST_APP_NAMESPACE_NAME}/*/*"
+export CONJUR_AUTHN_LOGIN="host/${TEST_APP_NAMESPACE_NAME}/*/*"
 
 deploy_test_env
 

--- a/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
+++ b/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
@@ -5,7 +5,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/some-apps/annotations-app"
+export CONJUR_AUTHN_LOGIN="host/some-apps/annotations-app"
 
 deploy_test_env
 

--- a/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
+++ b/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+create_secret_access_role
+
+create_secret_access_role_binding
+
+export CONJUR_AUTHN_LOGIN_KEY_VALUE="CONJUR_AUTHN_LOGIN host/some-apps/annotations-app"
+
+deploy_test_env
+
+echo "Verifying pod test_env has environment variable 'TEST_SECRET' with value 'supersecret'"
+pod_name=$(cli_get_pods_test_env | awk '{print $1}')
+verify_secret_value_in_pod $pod_name TEST_SECRET supersecret


### PR DESCRIPTION
Connected to cyberark/conjur#1260 & cyberark/conjur-authn-k8s-client#65

Add tests for authenticating a host that has its application identity defined in annotations.