### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2020-01-23
+
+### Changed
+  - Using a new conjur-authn-k8s-client version that enables authentication of
+    hosts that have their application identity defined in annotations.
+    
 ## [0.3.0] - 2019-12-26
 
 ### Changed

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "0.3.0"
+var Version = "0.4.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
Using a new conjur-authn-k8s-client version that enables authentication of
hosts that have their application identity defined in annotations