### PR TITLE
Send alert message to specific group on unsuccessful run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,8 +66,11 @@ pipeline {
   }
 
   post {
-    always {
+    success {
       cleanupAndNotify(currentBuild.currentResult)
+    }
+    unsuccessful {
+      cleanupAndNotify(currentBuild.currentResult, "#development", "@secrets-provider-for-k8s-owners")
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**
Add cucumber reports to Jenkins

**What ticket does this PR close?**
alert on failed builds #63 

Link to build in Jenkins (if appropriate)
failed scenario : https://jenkins.conjur.net/job/cyberark--secrets-provider-for-k8s/job/68-alert-on-failed-build/4/ . - sent well to jenkins with relevant group
[[cyberark--secrets-provider-for-k8s/68-alert-on-failed-build #4 FAILURE @secrets-provider-for-k8s-owners (Open)]]
succeed scenario : https://jenkins.conjur.net/job/cyberark--secrets-provider-for-k8s/job/68-alert-on-failed-build/6/ - sent well to jenkins with relevant group


