### PR TITLE
Bump authn-k8s client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+  - Bumped the authn-k8s client version to 0.16.1
+    (cyberark/conjur-authn-k8s-client#70)
+
 ## [0.4.0] - 2020-01-23
 
 ### Changed

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -11,7 +11,7 @@ text of the license associated with each component.
 SECTION 1: Apache License 2.0
 
 >>> github.com/cyberark/conjur-api-go v0.6.0
->>> github.com/cyberark/conjur-authn-k8s-client v0.14.0
+>>> github.com/cyberark/conjur-authn-k8s-client v0.16.1
 >>> github.com/googleapis/gnostic v0.3.1
 >>> github.com/modern-go/reflect2 v1.0.1
 >>> gopkg.in/yaml.v2 v2.2.2
@@ -69,9 +69,9 @@ Apache License 2.0 is applicable to the following component(s).
    See the License for the specific language governing permissions and
    limitations under the License.
 
->>> github.com/cyberark/conjur-authn-k8s-client v0.14.
+>>> github.com/cyberark/conjur-authn-k8s-client v0.16.1
 
-   Copyright (c) 2019 CyberArk Software Ltd. All rights reserved.
+   Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyberark/conjur-api-go v0.6.0
-	github.com/cyberark/conjur-authn-k8s-client v0.16.0
+	github.com/cyberark/conjur-authn-k8s-client v0.16.1
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cyberark/conjur-api-go v0.6.0 h1:QQYmFRhcCvmtZ9oSRoXCxWb7uRjppfu5lcEwo4HEjtg=
 github.com/cyberark/conjur-api-go v0.6.0/go.mod h1:uM96pLpckwYYAWRSbrsw+TT0y3kg49QCEGpdpa9dJ34=
-github.com/cyberark/conjur-authn-k8s-client v0.16.0 h1:qQEpaa3Yq+wao0tj+mk6jMG/XX6sM8cOyzq3GBQplPg=
-github.com/cyberark/conjur-authn-k8s-client v0.16.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
+github.com/cyberark/conjur-authn-k8s-client v0.16.1 h1:tiYIUYuBr578BCYlx+mbPiE4dWi+NsCu6Dy9cSRv4/M=
+github.com/cyberark/conjur-authn-k8s-client v0.16.1/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Partially resolves cyberark/conjur-authn-k8s-client#70

Bumps authn-k8s client version to 0.16.1.