### PR TITLE
Update deployment API to apps/v1

### DIFF
--- a/test/config/k8s/test-env.sh.yml
+++ b/test/config/k8s/test-env.sh.yml
@@ -13,7 +13,7 @@ CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_
 
 cat << EOL
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Update the deployment API referenced in the sample manifest from
`extensions/v1beta1` to `apps/v1`

`extensions/v1beta1` is officially deprecated in k8s 1.16: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

