### PR TITLE
Make secrets-provider-for-k8s stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@ pipeline {
 
   options {
     timestamps()
+    /* we want to avoid running in parallel otherwise we can get gcloud crashed : database is locked
+       working with same environment in parallel */
     disableConcurrentBuilds()
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
@@ -32,21 +34,21 @@ pipeline {
       }
     }
 
+    /* we want to avoid running in parallel otherwise we can get gcloud crashed : database is locked
+       working with same environment in parallel */
    stage ("Run Integration Tests on oss") {
       steps {
         script {
           def tasks = [:]
-          ["oss"].each { deployment ->
-            tasks["Kubernetes GKE, ${deployment}"] = {
-                sh "./bin/test_integration --docker --${deployment} --gke"
+            tasks["Kubernetes GKE, oss"] = {
+                sh "./bin/test_integration --docker --oss --gke"
             }
-            tasks["Openshift v3.11, ${deployment}"] = {
-                sh "./bin/test_integration --docker --${deployment} --oc311"
+            tasks["Openshift v3.11, oss"] = {
+                sh "./bin/test_integration --docker --oss --oc311"
             }
-            tasks["Openshift v3.10, ${deployment}"] = {
-                sh "./bin/test_integration --docker --${deployment} --oc310"
+            tasks["Openshift v3.10, oss"] = {
+                sh "./bin/test_integration --docker --oss --oc310"
             }
-          }
           parallel tasks
         }
       }
@@ -56,17 +58,15 @@ pipeline {
           steps {
             script {
               def tasks = [:]
-              ["dap"].each { deployment ->
-                tasks["Kubernetes GKE, ${deployment}"] = {
-                    sh "./bin/test_integration --docker --${deployment} --gke"
+                tasks["Kubernetes GKE, dap"] = {
+                    sh "./bin/test_integration --docker --dap --gke"
                 }
-                tasks["Openshift v3.11, ${deployment}"] = {
-                    sh "./bin/test_integration --docker --${deployment} --oc311"
+                tasks["Openshift v3.11, dap"] = {
+                    sh "./bin/test_integration --docker --dap --oc311"
                 }
-                tasks["Openshift v3.10, ${deployment}"] = {
-                    sh "./bin/test_integration --docker --${deployment} --oc310"
+                tasks["Openshift v3.10, dap"] = {
+                    sh "./bin/test_integration --docker --dap --oc310"
                 }
-              }
               parallel tasks
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,9 @@ pipeline {
 
   options {
     timestamps()
-    /* we want to avoid running in parallel otherwise we can get gcloud crashed : database is locked
-       working with same environment in parallel */
+    // We want to avoid running in parallel.
+    // When we have 2 build running on the same environment (gke env only) in parallel,
+    // we get the error "gcloud crashed : database is locked"
     disableConcurrentBuilds()
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
@@ -34,8 +35,9 @@ pipeline {
       }
     }
 
-    /* we want to avoid running in parallel otherwise we can get gcloud crashed : database is locked
-       working with same environment in parallel */
+    // We want to avoid running in parallel.
+    // When we have 2 build running on the same environment (gke env only) in parallel,
+    // we get the error "gcloud crashed : database is locked"
    stage ("Run Integration Tests on oss") {
       steps {
         script {
@@ -54,17 +56,17 @@ pipeline {
       }
     }
 
-    stage ("Run Integration Tests on dap") {
+    stage ("Run Integration Tests on DAP") {
           steps {
             script {
               def tasks = [:]
-                tasks["Kubernetes GKE, dap"] = {
+                tasks["Kubernetes GKE, DAP"] = {
                     sh "./bin/test_integration --docker --dap --gke"
                 }
-                tasks["Openshift v3.11, dap"] = {
+                tasks["Openshift v3.11, DAP"] = {
                     sh "./bin/test_integration --docker --dap --oc311"
                 }
-                tasks["Openshift v3.10, dap"] = {
+                tasks["Openshift v3.10, DAP"] = {
                     sh "./bin/test_integration --docker --dap --oc310"
                 }
               parallel tasks

--- a/test/2_create_test_app_namespace.sh
+++ b/test/2_create_test_app_namespace.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 announce "Creating Test App namespace."
 
 if [[ $PLATFORM == openshift ]]; then
-  oc login -u $OPENSHIFT_USERNAME
+  $cli_with_timeout "login -u $OPENSHIFT_USERNAME"
 fi
 
 set_namespace default
@@ -18,30 +18,30 @@ else
   echo "Creating '$TEST_APP_NAMESPACE_NAME' namespace."
 
   if [ $PLATFORM = "kubernetes" ]; then
-    $cli "create namespace $TEST_APP_NAMESPACE_NAME"
+    $cli_with_timeout "create namespace $TEST_APP_NAMESPACE_NAME"
   elif [ $PLATFORM = "openshift" ]; then
-    $cli "new-project $TEST_APP_NAMESPACE_NAME"
+    $cli_with_timeout "new-project $TEST_APP_NAMESPACE_NAME"
   fi
 
   set_namespace $TEST_APP_NAMESPACE_NAME
 fi
 
-$cli delete --ignore-not-found rolebinding test-app-conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
+$cli_with_timeout delete --ignore-not-found rolebinding test-app-conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
 
 TEST_DIR="config/k8s"
 if [[ "$PLATFORM" = "openshift" ]]; then
     TEST_DIR="config/openshift"
 fi
 
-./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli "create -f -"
+./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli_with_timeout "create -f -"
 
 if [[ $PLATFORM == openshift ]]; then
   # add permissions for Conjur admin user
-  oc adm policy add-role-to-user system:registry $OPENSHIFT_USERNAME
-  oc adm policy add-role-to-user system:image-builder $OPENSHIFT_USERNAME
+  $cli_with_timeout "adm policy add-role-to-user system:registry $OPENSHIFT_USERNAME"
+  $cli_with_timeout "adm policy add-role-to-user system:image-builder $OPENSHIFT_USERNAME"
 
-  oc adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n default
-  oc adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n $TEST_APP_NAMESPACE_NAME
+  $cli_with_timeout "adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n default"
+  $cli_with_timeout "adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n $TEST_APP_NAMESPACE_NAME"
   echo "Logging in as Conjur Openshift admin. Provide password as needed."
-  oc login -u $OPENSHIFT_USERNAME
+  $cli_with_timeout "login -u $OPENSHIFT_USERNAME"
 fi

--- a/test/2_create_test_app_namespace.sh
+++ b/test/2_create_test_app_namespace.sh
@@ -18,9 +18,9 @@ else
   echo "Creating '$TEST_APP_NAMESPACE_NAME' namespace."
 
   if [ $PLATFORM = "kubernetes" ]; then
-    $cli create namespace $TEST_APP_NAMESPACE_NAME
+    $cli "create namespace $TEST_APP_NAMESPACE_NAME"
   elif [ $PLATFORM = "openshift" ]; then
-    $cli new-project $TEST_APP_NAMESPACE_NAME
+    $cli "new-project $TEST_APP_NAMESPACE_NAME"
   fi
 
   set_namespace $TEST_APP_NAMESPACE_NAME
@@ -33,7 +33,7 @@ if [[ "$PLATFORM" = "openshift" ]]; then
     TEST_DIR="config/openshift"
 fi
 
-./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli create -f -
+./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli "create -f -"
 
 if [[ $PLATFORM == openshift ]]; then
   # add permissions for Conjur admin user

--- a/test/3_load_conjur_policies.sh
+++ b/test/3_load_conjur_policies.sh
@@ -33,10 +33,10 @@ if [[ "${DEPLOY_MASTER_CLUSTER}" == "true" ]]; then
 
   set_namespace "$CONJUR_NAMESPACE_NAME"
   conjur_cli_pod=$(get_conjur_cli_pod_name)
-  $cli "exec $conjur_cli_pod -- rm -rf /policy"
-  $cli "cp ./policy $conjur_cli_pod:/policy"
+  $cli_with_timeout "exec $conjur_cli_pod -- rm -rf /policy"
+  $cli_with_timeout "cp ./policy $conjur_cli_pod:/policy"
 
-  $cli "exec $conjur_cli_pod -- \
+  $cli_with_timeout "exec $conjur_cli_pod -- \
     bash -c \"
       CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_PASSWORD} \
       TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE_NAME} \
@@ -46,7 +46,7 @@ if [[ "${DEPLOY_MASTER_CLUSTER}" == "true" ]]; then
       /policy/load_policies.sh
     \""
 
-  $cli "exec $conjur_cli_pod -- rm -rf ./policy"
+  $cli_with_timeout "exec $conjur_cli_pod -- rm -rf ./policy"
 
   echo "Conjur policy loaded."
 fi

--- a/test/3_load_conjur_policies.sh
+++ b/test/3_load_conjur_policies.sh
@@ -33,20 +33,20 @@ if [[ "${DEPLOY_MASTER_CLUSTER}" == "true" ]]; then
 
   set_namespace "$CONJUR_NAMESPACE_NAME"
   conjur_cli_pod=$(get_conjur_cli_pod_name)
-  $cli exec $conjur_cli_pod -- rm -rf /policy
-  $cli cp ./policy $conjur_cli_pod:/policy
+  $cli "exec $conjur_cli_pod -- rm -rf /policy"
+  $cli "cp ./policy $conjur_cli_pod:/policy"
 
-  $cli exec $conjur_cli_pod -- \
-    bash -c "
+  $cli "exec $conjur_cli_pod -- \
+    bash -c \"
       CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_PASSWORD} \
       TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE_NAME} \
       CONJUR_VERSION=${CONJUR_VERSION} \
       POSTGRES_USERNAME=${POSTGRES_USERNAME} \
       POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
       /policy/load_policies.sh
-    "
+    \""
 
-  $cli exec $conjur_cli_pod -- rm -rf ./policy
+  $cli "exec $conjur_cli_pod -- rm -rf ./policy"
 
   echo "Conjur policy loaded."
 fi

--- a/test/4_init_conjur_cert_authority.sh
+++ b/test/4_init_conjur_cert_authority.sh
@@ -13,6 +13,6 @@ cmd='rake authn_k8s:ca_init['"conjur/authn-k8s/$AUTHENTICATOR_ID"]
 if [ "$CONJUR_DEPLOYMENT" = "dap" ]; then
   cmd='chpst -u conjur conjur-plugin-service possum '"$cmd"
 fi
-$cli exec $conjur_master -- $cmd
+$cli "exec $conjur_master -- $cmd"
 
 echo "Certificate authority initialized."

--- a/test/4_init_conjur_cert_authority.sh
+++ b/test/4_init_conjur_cert_authority.sh
@@ -13,6 +13,6 @@ cmd='rake authn_k8s:ca_init['"conjur/authn-k8s/$AUTHENTICATOR_ID"]
 if [ "$CONJUR_DEPLOYMENT" = "dap" ]; then
   cmd='chpst -u conjur conjur-plugin-service possum '"$cmd"
 fi
-$cli "exec $conjur_master -- $cmd"
+$cli_with_timeout "exec $conjur_master -- $cmd"
 
 echo "Certificate authority initialized."

--- a/test/run_demo.sh
+++ b/test/run_demo.sh
@@ -29,7 +29,7 @@ function main() {
 
   provideSecretAccessToServiceAccount
 
-  $cli create -f demo/k8s-secret.yml
+  $cli_without_timeout create -f demo/k8s-secret.yml
 
   deployDemoEnv
 
@@ -64,30 +64,30 @@ function deployConjur() {
 }
 
 function enableImagePull() {
-  $cli delete secret dockerpullsecret --ignore-not-found=true
+  $cli_without_timeout delete secret dockerpullsecret --ignore-not-found=true
   # TODO: replace the following with `oc create secret`
-  $cli secrets new-dockercfg dockerpullsecret \
+  $cli_without_timeout secrets new-dockercfg dockerpullsecret \
         --docker-server=${DOCKER_REGISTRY_PATH} \
         --docker-username=_ \
-        --docker-password=$($cli_no_timeout  whoami -t) \
+        --docker-password=$($cli_without_timeout  whoami -t) \
         --docker-email=_
-  $cli secrets add serviceaccount/default secrets/dockerpullsecret --for=pull
+  $cli_without_timeout secrets add serviceaccount/default secrets/dockerpullsecret --for=pull
 }
 
 function provideSecretAccessToServiceAccount() {
-  $cli delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true
-  ./$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli create -f -
+  $cli_without_timeout delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true
+  ./$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_without_timeout create -f -
 
-  ./$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli create -f -
+  ./$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_without_timeout create -f -
 }
 
 function deployDemoEnv() {
-  conjur_node_pod=$($cli_no_timeout  get pod --namespace $CONJUR_NAMESPACE_NAME --selector=app=conjur-node -o=jsonpath='{.items[].metadata.name}')
+  conjur_node_pod=$($cli_without_timeout  get pod --namespace $CONJUR_NAMESPACE_NAME --selector=app=conjur-node -o=jsonpath='{.items[].metadata.name}')
 
   # this variable is consumed in pet-store-env.sh.yml
-  export CONJUR_SSL_CERTIFICATE=$($cli_no_timeout  exec --namespace $CONJUR_NAMESPACE_NAME "${conjur_node_pod}" cat /opt/conjur/etc/ssl/conjur-master.pem)
+  export CONJUR_SSL_CERTIFICATE=$($cli_without_timeout  exec --namespace $CONJUR_NAMESPACE_NAME "${conjur_node_pod}" cat /opt/conjur/etc/ssl/conjur-master.pem)
 
-  ./demo/pet-store-env.sh.yml | $cli create -f -
+  ./demo/pet-store-env.sh.yml | $cli_with_timeout create -f -
 }
 
 main

--- a/test/run_demo.sh
+++ b/test/run_demo.sh
@@ -69,7 +69,7 @@ function enableImagePull() {
   $cli secrets new-dockercfg dockerpullsecret \
         --docker-server=${DOCKER_REGISTRY_PATH} \
         --docker-username=_ \
-        --docker-password=$($cli whoami -t) \
+        --docker-password=$($cli_no_timeout  whoami -t) \
         --docker-email=_
   $cli secrets add serviceaccount/default secrets/dockerpullsecret --for=pull
 }
@@ -82,10 +82,10 @@ function provideSecretAccessToServiceAccount() {
 }
 
 function deployDemoEnv() {
-  conjur_node_pod=$($cli get pod --namespace $CONJUR_NAMESPACE_NAME --selector=app=conjur-node -o=jsonpath='{.items[].metadata.name}')
+  conjur_node_pod=$($cli_no_timeout  get pod --namespace $CONJUR_NAMESPACE_NAME --selector=app=conjur-node -o=jsonpath='{.items[].metadata.name}')
 
   # this variable is consumed in pet-store-env.sh.yml
-  export CONJUR_SSL_CERTIFICATE=$($cli exec --namespace $CONJUR_NAMESPACE_NAME "${conjur_node_pod}" cat /opt/conjur/etc/ssl/conjur-master.pem)
+  export CONJUR_SSL_CERTIFICATE=$($cli_no_timeout  exec --namespace $CONJUR_NAMESPACE_NAME "${conjur_node_pod}" cat /opt/conjur/etc/ssl/conjur-master.pem)
 
   ./demo/pet-store-env.sh.yml | $cli create -f -
 }

--- a/test/stop
+++ b/test/stop
@@ -6,7 +6,7 @@ set -euo pipefail
 set_namespace default
 
 if [[ $PLATFORM == openshift ]]; then
-  oc login -u $OPENSHIFT_USERNAME
+  $cli login -u $OPENSHIFT_USERNAME
 fi
 
 if has_namespace $TEST_APP_NAMESPACE_NAME; then

--- a/test/stop
+++ b/test/stop
@@ -6,11 +6,11 @@ set -euo pipefail
 set_namespace default
 
 if [[ $PLATFORM == openshift ]]; then
-  $cli login -u $OPENSHIFT_USERNAME
+  $cli_with_timeout login -u $OPENSHIFT_USERNAME
 fi
 
 if has_namespace $TEST_APP_NAMESPACE_NAME; then
-  $cli delete namespace $TEST_APP_NAMESPACE_NAME
+  $cli_with_timeout delete namespace $TEST_APP_NAMESPACE_NAME
 
   printf "Waiting for $TEST_APP_NAMESPACE_NAME namespace deletion to complete"
 

--- a/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
+++ b/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
@@ -12,4 +12,4 @@ deploy_test_env
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable 'SECRETS_DESTINATION' must be provided'"
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK004E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
+++ b/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
@@ -12,4 +12,4 @@ deploy_test_env
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable 'SECRETS_DESTINATION' must be provided'"
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error CAKC015E Login failed"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CAKC015E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CAKC015E"

--- a/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error CAKC015E Login failed"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CAKC015E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CAKC015E"

--- a/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error CSPFK034E Failed to retrieve Conjur secrets"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK034E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK034E"

--- a/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error CSPFK034E Failed to retrieve Conjur secrets"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK034E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK034E"

--- a/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
+++ b/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
@@ -2,10 +2,10 @@
 set -euxo pipefail
 
 echo "Creating secrets access role"
-$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli "create -f -"
+$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_with_timeout "create -f -"
 
 echo "Creating secrets access role binding"
-$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli "create -f -"
+$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_with_timeout "create -f -"
 
 deploy_test_env
 
@@ -19,18 +19,18 @@ if [[ "$PLATFORM" = "kubernetes" ]]; then
     # Using scaling down instead of delete because in GKE, deleting a pod automatically triggers the spin up of another one
     # and therefore two pods were begin returned when parsing the namespace which messes up the test. While with scale down,
     # we can are able to successfully delete the pods and only deploy a new one, when we scale back up.
-    $cli "scale deployment test-env --replicas=0"
+    $cli_with_timeout "scale deployment test-env --replicas=0"
 
     # Waiting until pod is successfully removed from the namespace before advancing.
-    $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
+    $cli_with_timeout "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
 
     test_app_set_secret secrets/test_secret secret2
 
-    $cli "scale deployment test-env --replicas=1"
+    $cli_with_timeout "scale deployment test-env --replicas=1"
 elif [ $PLATFORM = "openshift" ]; then
     test_app_set_secret secrets/test_secret secret2
 
-    $cli "delete pod $pod_name1"
+    $cli_with_timeout "delete pod $pod_name1"
 fi
 
 pod_name2=$(cli_get_pods_test_env | awk '{print $1}')
@@ -41,14 +41,14 @@ test_app_set_secret secrets/test_secret secret3
 
 if [[ "$PLATFORM" = "kubernetes" ]]; then
     echo "Setting deployment test-env to replicas"
-    $cli "scale deployment test-env --replicas=3"
+    $cli_with_timeout "scale deployment test-env --replicas=3"
 elif [ $PLATFORM = "openshift" ]; then
     echo "Setting deploymentconfig test-env to replicas"
-    $cli "scale dc test-env --replicas=3"
+    $cli_with_timeout "scale dc test-env --replicas=3"
 fi
 
 echo "Waiting for 3 running pod test-env"
-$cli "get pods | grep test-env | grep Running | wc -l | tr -d ' ' | grep '^3$'"
+$cli_with_timeout "get pods | grep test-env | grep Running | wc -l | tr -d ' ' | grep '^3$'"
 
 echo "Iterate over new pods and verify their secret was updated"
 pod_names=$(cli_get_pods_test_env | awk '{print $1}' | grep -v $pod_name2)

--- a/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
+++ b/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
@@ -2,10 +2,10 @@
 set -euxo pipefail
 
 echo "Creating secrets access role"
-$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli create -f -
+$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli "create -f -"
 
 echo "Creating secrets access role binding"
-$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli create -f -
+$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli "create -f -"
 
 deploy_test_env
 
@@ -19,18 +19,18 @@ if [[ "$PLATFORM" = "kubernetes" ]]; then
     # Using scaling down instead of delete because in GKE, deleting a pod automatically triggers the spin up of another one
     # and therefore two pods were begin returned when parsing the namespace which messes up the test. While with scale down,
     # we can are able to successfully delete the pods and only deploy a new one, when we scale back up.
-    $cli scale deployment test-env --replicas=0
+    $cli "scale deployment test-env --replicas=0"
 
     # Waiting until pod is successfully removed from the namespace before advancing.
-    wait_for_it 600 "$cli get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
+    $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
 
     test_app_set_secret secrets/test_secret secret2
 
-    $cli scale deployment test-env --replicas=1
+    $cli "scale deployment test-env --replicas=1"
 elif [ $PLATFORM = "openshift" ]; then
     test_app_set_secret secrets/test_secret secret2
 
-    $cli delete pod $pod_name1
+    $cli "delete pod $pod_name1"
 fi
 
 pod_name2=$(cli_get_pods_test_env | awk '{print $1}')
@@ -41,14 +41,14 @@ test_app_set_secret secrets/test_secret secret3
 
 if [[ "$PLATFORM" = "kubernetes" ]]; then
     echo "Setting deployment test-env to replicas"
-    $cli scale deployment test-env --replicas=3
+    $cli "scale deployment test-env --replicas=3"
 elif [ $PLATFORM = "openshift" ]; then
     echo "Setting deploymentconfig test-env to replicas"
-    $cli scale dc test-env --replicas=3
+    $cli "scale dc test-env --replicas=3"
 fi
 
 echo "Waiting for 3 running pod test-env"
-wait_for_it 600 "$cli get pods | grep test-env | grep Running | wc -l | tr -d ' ' | grep '^3$'"
+$cli "get pods | grep test-env | grep Running | wc -l | tr -d ' ' | grep '^3$'"
 
 echo "Iterate over new pods and verify their secret was updated"
 pod_names=$(cli_get_pods_test_env | awk '{print $1}' | grep -v $pod_name2)

--- a/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
+++ b/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005E Provided incorrect value for environment variable SECRETS_DESTINATION'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005E"

--- a/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
+++ b/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005E Provided incorrect value for environment variable SECRETS_DESTINATION'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK005E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005E"

--- a/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
+++ b/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK007E Setting SECRETS_DESTINATION environment variable to 'k8s_secrets' must run as init container'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK007E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK007E"

--- a/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
+++ b/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK007E Setting SECRETS_DESTINATION environment variable to 'k8s_secrets' must run as init container'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK007E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK007E"

--- a/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
+++ b/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK004D Failed to retrieve k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK004D'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"

--- a/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
+++ b/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK004D Failed to retrieve k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"

--- a/test/test_cases/TEST_ID_6_no_patch_permission_to_secret.sh
+++ b/test/test_cases/TEST_ID_6_no_patch_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005D Failed to patch k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005D"

--- a/test/test_cases/TEST_ID_6_no_patch_permission_to_secret.sh
+++ b/test/test_cases/TEST_ID_6_no_patch_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005D Failed to patch k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK005D'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005D"

--- a/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
+++ b/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
+++ b/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK004E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
+++ b/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting Secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
+++ b/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting Secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK004E'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"

--- a/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
+++ b/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
@@ -11,7 +11,7 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with debug message 'CSPFK004D Failed to retrieve k8s secret. Reason: secrets K8S_SECRETS_invalid_value not found'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-wait_for_it 600 "$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK004D'"
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
 
 echo "Expecting secrets provider to fail with error 'CSPFK020E Failed to retrieve k8s secret'"
-$cli logs $pod_name -c cyberark-secrets-provider | grep 'CSPFK020E'
+$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK020E"

--- a/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
+++ b/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
@@ -11,7 +11,7 @@ deploy_test_env
 
 echo "Expecting secrets provider to fail with debug message 'CSPFK004D Failed to retrieve k8s secret. Reason: secrets K8S_SECRETS_invalid_value not found'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
 
 echo "Expecting secrets provider to fail with error 'CSPFK020E Failed to retrieve k8s secret'"
-$cli "logs $pod_name -c cyberark-secrets-provider | grep CSPFK020E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK020E"

--- a/test/test_cases/test_case_setup.sh
+++ b/test/test_cases/test_case_setup.sh
@@ -4,25 +4,25 @@ set -euxo pipefail
 announce "Creating image pull secret."
 
 if [[ "${PLATFORM}" == "kubernetes" ]]; then
-     $cli delete --ignore-not-found secret dockerpullsecret
+     $cli_with_timeout delete --ignore-not-found secret dockerpullsecret
 
-     $cli create secret docker-registry dockerpullsecret \
+     $cli_with_timeout create secret docker-registry dockerpullsecret \
       --docker-server=$DOCKER_REGISTRY_URL \
       --docker-username=_ \
       --docker-password=_ \
       --docker-email=_
 elif [[ "$PLATFORM" == "openshift" ]]; then
-    $cli delete --ignore-not-found secrets dockerpullsecret
+    $cli_with_timeout delete --ignore-not-found secrets dockerpullsecret
 
     # TODO: replace the following with `$cli create secret`
-    $cli secrets new-dockercfg dockerpullsecret \
+    $cli_with_timeout secrets new-dockercfg dockerpullsecret \
           --docker-server=${DOCKER_REGISTRY_PATH} \
           --docker-username=_ \
-          --docker-password=$($cli whoami -t) \
+          --docker-password=$($cli_with_timeout whoami -t) \
           --docker-email=_
 
-    $cli secrets add serviceaccount/default secrets/dockerpullsecret --for=pull
+    $cli_with_timeout secrets add serviceaccount/default secrets/dockerpullsecret --for=pull
 fi
 
 echo "Create secret k8s-secret"
-$cli create -f $TEST_CASES_DIR/k8s-secret.yml
+$cli_with_timeout create -f $TEST_CASES_DIR/k8s-secret.yml

--- a/test/test_cases/test_case_teardown.sh
+++ b/test/test_cases/test_case_teardown.sh
@@ -5,27 +5,27 @@ set -euxo pipefail
 set_namespace $CONJUR_NAMESPACE_NAME
 
 configure_cli_pod
-$cli exec $(get_conjur_cli_pod_name) -- conjur variable values add secrets/test_secret "supersecret"
+$cli "exec $(get_conjur_cli_pod_name) -- conjur variable values add secrets/test_secret \"supersecret\""
 
 set_namespace $TEST_APP_NAMESPACE_NAME
 
-$cli delete secret dockerpullsecret --ignore-not-found=true
+$cli "delete secret dockerpullsecret --ignore-not-found=true"
 
-$cli delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true
+$cli "delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true"
 
-$cli delete secret test-k8s-secret --ignore-not-found=true
+$cli "delete secret test-k8s-secret --ignore-not-found=true"
 
-$cli delete serviceaccount ${TEST_APP_NAMESPACE_NAME}-sa --ignore-not-found=true
+$cli "delete serviceaccount ${TEST_APP_NAMESPACE_NAME}-sa --ignore-not-found=true"
 
-$cli delete rolebinding secrets-access-role-binding --ignore-not-found=true
+$cli "delete rolebinding secrets-access-role-binding --ignore-not-found=true"
 
 if [ "${PLATFORM}" = "kubernetes" ]; then
-  $cli delete deployment test-env --ignore-not-found=true
+  $cli "delete deployment test-env --ignore-not-found=true"
 elif [ "${PLATFORM}" = "openshift" ]; then
-  $cli delete deploymentconfig test-env --ignore-not-found=true
+  $cli "delete deploymentconfig test-env --ignore-not-found=true"
 fi
 
-$cli delete configmap conjur-master-ca-env --ignore-not-found=true
+$cli "delete configmap conjur-master-ca-env --ignore-not-found=true"
 
  echo "Verifying there are no (terminating) pods of type test-env"
- wait_for_it 600 "$cli get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
+ $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"

--- a/test/test_cases/test_case_teardown.sh
+++ b/test/test_cases/test_case_teardown.sh
@@ -5,27 +5,27 @@ set -euxo pipefail
 set_namespace $CONJUR_NAMESPACE_NAME
 
 configure_cli_pod
-$cli "exec $(get_conjur_cli_pod_name) -- conjur variable values add secrets/test_secret \"supersecret\""
+$cli_with_timeout "exec $(get_conjur_cli_pod_name) -- conjur variable values add secrets/test_secret \"supersecret\""
 
 set_namespace $TEST_APP_NAMESPACE_NAME
 
-$cli "delete secret dockerpullsecret --ignore-not-found=true"
+$cli_with_timeout "delete secret dockerpullsecret --ignore-not-found=true"
 
-$cli "delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true"
+$cli_with_timeout "delete clusterrole secrets-access-${UNIQUE_TEST_ID} --ignore-not-found=true"
 
-$cli "delete secret test-k8s-secret --ignore-not-found=true"
+$cli_with_timeout "delete secret test-k8s-secret --ignore-not-found=true"
 
-$cli "delete serviceaccount ${TEST_APP_NAMESPACE_NAME}-sa --ignore-not-found=true"
+$cli_with_timeout "delete serviceaccount ${TEST_APP_NAMESPACE_NAME}-sa --ignore-not-found=true"
 
-$cli "delete rolebinding secrets-access-role-binding --ignore-not-found=true"
+$cli_with_timeout "delete rolebinding secrets-access-role-binding --ignore-not-found=true"
 
 if [ "${PLATFORM}" = "kubernetes" ]; then
-  $cli "delete deployment test-env --ignore-not-found=true"
+  $cli_with_timeout "delete deployment test-env --ignore-not-found=true"
 elif [ "${PLATFORM}" = "openshift" ]; then
-  $cli "delete deploymentconfig test-env --ignore-not-found=true"
+  $cli_with_timeout "delete deploymentconfig test-env --ignore-not-found=true"
 fi
 
-$cli "delete configmap conjur-master-ca-env --ignore-not-found=true"
+$cli_with_timeout "delete configmap conjur-master-ca-env --ignore-not-found=true"
 
  echo "Verifying there are no (terminating) pods of type test-env"
- $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"
+ $cli_with_timeout "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^0$'"

--- a/test/test_with_summon.sh
+++ b/test/test_with_summon.sh
@@ -45,8 +45,8 @@ if [ "$CONJUR_DEPLOYMENT" = "oss" ]; then
     selector="app=conjur-cli"
     cert_location="/root/conjur-${CONJUR_ACCOUNT}.pem"
 fi
-conjur_pod_name=$($cli get pods --selector=$selector --namespace $CONJUR_NAMESPACE_NAME --no-headers | awk '{ print $1 }' | head -1)
-ssl_cert=$($cli "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME cat $cert_location")
+conjur_pod_name=$($cli_with_timeout get pods --selector=$selector --namespace $CONJUR_NAMESPACE_NAME --no-headers | awk '{ print $1 }' | head -1)
+ssl_cert=$($cli_with_timeout "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME cat $cert_location")
 
 export CONJUR_SSL_CERTIFICATE=$ssl_cert
 

--- a/test/test_with_summon.sh
+++ b/test/test_with_summon.sh
@@ -45,11 +45,8 @@ if [ "$CONJUR_DEPLOYMENT" = "oss" ]; then
     selector="app=conjur-cli"
     cert_location="/root/conjur-${CONJUR_ACCOUNT}.pem"
 fi
-conjur_pod_name=$($cli get pods \
-                      --selector=$selector \
-                      --namespace $CONJUR_NAMESPACE_NAME \
-                      --no-headers | awk '{ print $1 }' | head -1)
-ssl_cert=$($cli exec "${conjur_pod_name}" --namespace $CONJUR_NAMESPACE_NAME cat $cert_location)
+conjur_pod_name=$($cli get pods --selector=$selector --namespace $CONJUR_NAMESPACE_NAME --no-headers | awk '{ print $1 }' | head -1)
+ssl_cert=$($cli "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME cat $cert_location")
 
 export CONJUR_SSL_CERTIFICATE=$ssl_cert
 

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -31,11 +31,11 @@ wait_for_it() {
 }
 
 if [ $PLATFORM = "kubernetes" ]; then
-    cli="wait_for_it 600 kubectl"
-    cli_no_timeout=kubectl
+    cli_with_timeout="wait_for_it 600 kubectl"
+    cli_without_timeout=kubectl
 elif [ $PLATFORM = "openshift" ]; then
-    cli="wait_for_it 600 oc"
-    cli_no_timeout=oc
+    cli_with_timeout="wait_for_it 600 oc"
+    cli_without_timeout=oc
 fi
 
 check_env_var() {
@@ -56,8 +56,9 @@ announce() {
 }
 
 has_namespace() {
-  #We dont need retry because some of the scenarios waiting for false
-  if $cli_no_timeout get namespace  "$1" > /dev/null; then
+  # We don't need a timeout here as false is a valid output.
+  # Running with a timeout will run this command repeatedly for no reason, ending with the same result
+  if $cli_without_timeout get namespace  "$1" > /dev/null; then
     true
   else
     false
@@ -69,7 +70,7 @@ set_namespace() {
     printf "Error in %s/%s - expecting 1 arg.\n" "$(pwd)" $0
     exit 1
   fi
-  $cli config set-context "$($cli config current-context)" --namespace="$1" > /dev/null
+  $cli_with_timeout config set-context "$($cli_with_timeout config current-context)" --namespace="$1" > /dev/null
 }
 
 get_master_pod_name() {
@@ -77,12 +78,12 @@ get_master_pod_name() {
   if [ "$CONJUR_DEPLOYMENT" = "dap" ]; then
       app_name=conjur-node
   fi
-  pod_list=$($cli get pods --selector app=$app_name,role=master --no-headers | awk '{ print $1 }')
+  pod_list=$($cli_with_timeout get pods --selector app=$app_name,role=master --no-headers | awk '{ print $1 }')
   echo $pod_list | awk '{print $1}'
 }
 
 get_conjur_cli_pod_name() {
-  pod_list=$($cli get pods --selector app=conjur-cli --no-headers | awk '{ print $1 }')
+  pod_list=$($cli_with_timeout get pods --selector app=conjur-cli --no-headers | awk '{ print $1 }')
   echo $pod_list | awk '{print $1}'
 }
 
@@ -143,9 +144,9 @@ configure_cli_pod() {
 
   conjur_cli_pod=$(get_conjur_cli_pod_name)
 
-  $cli "exec $conjur_cli_pod -- bash -c \"yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url\""
+  $cli_with_timeout "exec $conjur_cli_pod -- bash -c \"yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url\""
 
-  $cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+  $cli_with_timeout exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
 }
 
 function deploy_test_env {
@@ -163,29 +164,29 @@ function deploy_test_env {
   export CONJUR_AUTHN_URL=$conjur_authenticator_url
 
   echo "Deploying test-env"
-  $TEST_CASES_DIR/test-env.sh.yml | $cli create -f -
+  $TEST_CASES_DIR/test-env.sh.yml | $cli_with_timeout create -f -
 
   expected_num_replicas=`$TEST_CASES_DIR/test-env.sh.yml |  awk '/replicas:/ {print $2}' `
 
   # Deployment (Deployment for k8s and DeploymentConfig for Openshift) might fail on error flows, even before creating the pods. If so, re-deploy.
   if [[ "$PLATFORM" = "kubernetes" ]]; then
-      $cli "get deployment test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| kubectl rollout latest deployment test-env"
+      $cli_with_timeout "get deployment test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_with_timeout rollout latest deployment test-env"
   elif [[ "$PLATFORM" = "openshift" ]]; then
-      $cli "get dc/test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| oc rollout latest dc/test-env"
+      $cli_with_timeout "get dc/test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_with_timeout rollout latest dc/test-env"
   fi
 
   echo "Expecting for $expected_num_replicas deployed pods"
-  $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | grep $expected_num_replicas"
+  $cli_with_timeout "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | grep $expected_num_replicas"
 }
 
 function create_secret_access_role () {
   echo "Creating secrets access role"
-  $TEST_CASES_DIR/secrets-access-role.sh.yml | $cli create -f -
+  $TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_with_timeout create -f -
 }
 
 function create_secret_access_role_binding () {
   echo "Creating secrets access role binding"
-  $TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli create -f -
+  $TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_with_timeout create -f -
 }
 
 function test_app_set_secret () {
@@ -194,7 +195,7 @@ function test_app_set_secret () {
   echo "Set secret '$SECRET_NAME' to '$SECRET_VALUE'"
   set_namespace "$CONJUR_NAMESPACE_NAME"
   configure_cli_pod
-  $cli "exec $(get_conjur_cli_pod_name) -- conjur variable values add $SECRET_NAME $SECRET_VALUE"
+  $cli_with_timeout "exec $(get_conjur_cli_pod_name) -- conjur variable values add $SECRET_NAME $SECRET_VALUE"
   set_namespace $TEST_APP_NAMESPACE_NAME
 }
 
@@ -218,12 +219,12 @@ yaml_print_key_name_value () {
 }
 
 cli_get_pods_test_env () {
-  $cli "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers"
+  $cli_with_timeout "get pods --namespace=$TEST_APP_NAMESPACE_NAME --selector app=test-env --no-headers"
 }
 
 verify_secret_value_in_pod () {
   pod_name=$1
   secret_name=$2
   expected_value=$3
-  $cli "exec -n $TEST_APP_NAMESPACE_NAME ${pod_name} printenv| grep $secret_name | cut -d '=' -f 2 | grep $expected_value"
+  $cli_with_timeout "exec -n $TEST_APP_NAMESPACE_NAME ${pod_name} printenv| grep $secret_name | cut -d '=' -f 2 | grep $expected_value"
 }

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -170,9 +170,9 @@ function deploy_test_env {
 
   # Deployment (Deployment for k8s and DeploymentConfig for Openshift) might fail on error flows, even before creating the pods. If so, re-deploy.
   if [[ "$PLATFORM" = "kubernetes" ]]; then
-      $cli_with_timeout "get deployment test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_with_timeout rollout latest deployment test-env"
+      $cli_with_timeout "get deployment test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_without_timeout rollout latest deployment test-env"
   elif [[ "$PLATFORM" = "openshift" ]]; then
-      $cli_with_timeout "get dc/test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_with_timeout rollout latest dc/test-env"
+      $cli_with_timeout "get dc/test-env -o jsonpath={.status.replicas} | grep '^${expected_num_replicas}$'|| $cli_without_timeout rollout latest dc/test-env"
   fi
 
   echo "Expecting for $expected_num_replicas deployed pods"


### PR DESCRIPTION
secrets-provider-for-k8s is not stable and i did the following things to improve this job:
1. main issue was that sometimes we get route issue from os (known issue) 
`[2020-03-02T19:39:07.653Z] Unable to connect to the server: dial tcp 54.197.37.237:8443: connect: no route to host`
Since we already had retry function in the code, i changed the mechanism to make sure all our cli commands will use this function. 
I ran more than 150 runs and find 6 different commands that failed on the same issue and fixed by this solution. 
2. i saw sometimes gcloud crashed : database is locked -SQLite is meant to be a lightweight database, and thus can't support a high level of concurrency (today all the environments run in parallel ) i separate our work to run concurrency dap/oss

*Please be aware that this PR will not solve retry issue that may occur in kubernetes-conjur-deploy.
During my tests this problem occur 8/150 runs*

this code will . not pushed unless i will see 10 success job 