### PR TITLE
update pipe commands with retry and update kubectl version

### DIFF
--- a/test/2_create_test_app_namespace.sh
+++ b/test/2_create_test_app_namespace.sh
@@ -33,7 +33,7 @@ if [[ "$PLATFORM" = "openshift" ]]; then
     TEST_DIR="config/openshift"
 fi
 
-./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli_with_timeout "create -f -"
+wait_for_it 600  "./$TEST_DIR/test-app-conjur-authenticator-role-binding.sh.yml | $cli_without_timeout create -f -"
 
 if [[ $PLATFORM == openshift ]]; then
   # add permissions for Conjur admin user

--- a/test/summon/secrets.yml
+++ b/test/summon/secrets.yml
@@ -1,5 +1,5 @@
 common:
-  KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
+  KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
   OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
   POSTGRES_DATABASE: !var qa/xa/p2p/postgresql/database
   POSTGRES_HOSTNAME: !var qa/xa/p2p/postgresql/hostname

--- a/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
+++ b/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
@@ -2,10 +2,10 @@
 set -euxo pipefail
 
 echo "Creating secrets access role"
-$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_with_timeout "create -f -"
+wait_for_it 600  "$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_without_timeout create -f -"
 
 echo "Creating secrets access role binding"
-$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_with_timeout "create -f -"
+wait_for_it 600 "$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_without_timeout create -f -"
 
 deploy_test_env
 

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -164,7 +164,7 @@ function deploy_test_env {
   export CONJUR_AUTHN_URL=$conjur_authenticator_url
 
   echo "Deploying test-env"
-  $TEST_CASES_DIR/test-env.sh.yml | $cli_with_timeout create -f -
+  wait_for_it 600 "$TEST_CASES_DIR/test-env.sh.yml | $cli_without_timeout create -f -"
 
   expected_num_replicas=`$TEST_CASES_DIR/test-env.sh.yml |  awk '/replicas:/ {print $2}' `
 
@@ -181,12 +181,12 @@ function deploy_test_env {
 
 function create_secret_access_role () {
   echo "Creating secrets access role"
-  $TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_with_timeout create -f -
+  wait_for_it 600  "$TEST_CASES_DIR/secrets-access-role.sh.yml | $cli_without_timeout create -f -"
 }
 
 function create_secret_access_role_binding () {
   echo "Creating secrets access role binding"
-  $TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_with_timeout create -f -
+  wait_for_it 600  "$TEST_CASES_DIR/secrets-access-role-binding.sh.yml | $cli_without_timeout create -f -"
 }
 
 function test_app_set_secret () {


### PR DESCRIPTION
- update commands with pipe which didnt worked well with retry and - those command didnt worked well before with the retry, since the retry command need to be for all the command.

- update kubectl to latest stable - our version was out of date changed from 9.7 to 10.8

The commit is updated with those 2 changes.