### PR TITLE
Remove CONJUR_VERSION env var as it is not needed anymore

### DIFF
--- a/test/config/k8s/test-env.sh.yml
+++ b/test/config/k8s/test-env.sh.yml
@@ -63,9 +63,6 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
 
-          - name: CONJUR_VERSION
-            value: '5'
-
           - name: CONJUR_APPLIANCE_URL
             value: ${CONJUR_APPLIANCE_URL}
 

--- a/test/config/openshift/test-env.sh.yml
+++ b/test/config/openshift/test-env.sh.yml
@@ -62,9 +62,6 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
 
-          - name: CONJUR_VERSION
-            value: '5'
-
           - name: CONJUR_APPLIANCE_URL
             value: ${CONJUR_APPLIANCE_URL}
 

--- a/test/demo/pet-store-env.sh.yml
+++ b/test/demo/pet-store-env.sh.yml
@@ -87,9 +87,6 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
 
-            - name: CONJUR_VERSION
-              value: '5'
-
             - name: CONJUR_APPLIANCE_URL
               value: >-
                 https://conjur-follower.${CONJUR_NAMESPACE_NAME}.svc.cluster.local/api

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -117,7 +117,6 @@ function runDockerCommand() {
     -e GCLOUD_SERVICE_KEY=/tmp$GCLOUD_SERVICE_KEY \
     -e MINIKUBE \
     -e MINISHIFT \
-    -e CONJUR_VERSION \
     -e CONJUR_DEPLOYMENT \
     -e RUN_IN_DOCKER \
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \


### PR DESCRIPTION
We are now consuming a newer version of conjur-authn-k8s-client that doesn't require the CONJUR_VERSION env var, and it will be defaulted to `5` if not present.

As we test only in version 5 we should remove this env var from our test env to verify
it is not required.