### PR TITLE
Update supported OSS version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ from DAP or Conjur.
 
 - Openshift 3.9, 3.10, and 3.11
 - DAP 11.1+
-- Conjur 5.5.0+
+- Conjur OSS v1.4.2+
 
 # Releases
 


### PR DESCRIPTION
Previously the README stated the Conjur version as 5.5, but Conjur OSS is on a 1.x versioning scheme (See https://github.com/cyberark/conjur/blob/master/VERSION)

This updates the README to point to the correct first supported Conjur OSS version, 1.4.2, which is the version of Conjur OSS included in DAP 11.1.