### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0] - 2020-05-19
 ### Changed
 - Bumped the authn-k8s client version to 0.16.1
   (cyberark/conjur-authn-k8s-client#70)
@@ -37,7 +38,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v0.2.0

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "0.4.0"
+var Version = "1.0.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Changed
- Bumped the authn-k8s client version to 0.16.1
  (cyberark/conjur-authn-k8s-client#70)

### Fixed
- Fixed issue with providing complex Conjur secrets (#77). The secrets-provider
  now updates k8s secrets using `update` instead of `patch` so the service-account
  needs to have that permission.