### PR TITLE
Send slack notification on master failure only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,13 @@ pipeline {
       cleanupAndNotify(currentBuild.currentResult)
     }
     unsuccessful {
-      cleanupAndNotify(currentBuild.currentResult, "#development", "@secrets-provider-for-k8s-owners")
+        script {
+            if (env.BRANCH_NAME == 'master') {
+              cleanupAndNotify(currentBuild.currentResult, "#development", "@secrets-provider-for-k8s-owners")
+            } else {
+              cleanupAndNotify(currentBuild.currentResult, "#development")
+            }
+        }
     }
   }
 }


### PR DESCRIPTION
We want to notify failure to all group only when it run on master.

I run the following test:
PR - success
PR - failure (slack message wasent send to group channel)
Master - success
Master - failure (slack message sent to group channel)

Related to #96 