### PR TITLE
Add documentation that Red Hat certified is available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,4 +142,10 @@ follow the instructions in this section.
 
 ### Publish the git release
 1. In the GitHub UI, create a release from the new tag and copy the change log
-   for the new version into the GitHub release description.
+for the new version into the GitHub release description.
+1. The Jenkins pipeline auto-publishes new images to DockerHub, but to publish the Red Hat certified image you will need 
+to visit its [management page](https://connect.redhat.com/project/4381831/view) and manually publish the image.
+
+### Publish the Red Hat image
+1. Visit the [Red Hat project page](https://connect.redhat.com/project/4381831/view) once the images have been pushed 
+and manually choose to publish the latest release.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ When we release a version, we push the following images to Dockerhub:
 1. Major.Minor
 1. Major
 
+We also push the Major.Minor.Build image to our Red Hat registry.
+
 ## Stable release definition
 
 The CyberArk Secrets Provider for Kubernetes is considered stable when it meets the core acceptance criteria:


### PR DESCRIPTION
Our RH image has been approved and now we are Red Hat certified

This PR adds the following:
- Add content to README and CONTRIBUTING docs defining publish process

Connected to: https://app.zenhub.com/workspaces/palmtree-5d99d900491c060001c85cba/issues/cyberark/secrets-provider-for-k8s/112