### PR TITLE
Add UTs for config package

### DIFF
--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -43,7 +43,8 @@ func NewFromEnv() (*Config, error) {
 	// Split the comma-separated list into an array
 	requiredK8sSecrets := strings.Split(k8sSecretsList, ",")
 
-	storeType, err := getStoreType(os.Getenv("SECRETS_DESTINATION"))
+	storeType := os.Getenv("SECRETS_DESTINATION")
+	err := validateStoreType(storeType)
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +56,13 @@ func NewFromEnv() (*Config, error) {
 	}, nil
 }
 
-func getStoreType(secretsDestination string) (string, error) {
-	var storeType string
-	if secretsDestination == K8S {
-		storeType = K8S
-	} else {
-		// In case "SECRETS_DESTINATION" exists and is configured with incorrect value
-		return "", log.RecordedError(messages.CSPFK005E, "SECRETS_DESTINATION")
+func validateStoreType(storeType string) error {
+	validStoreTypes := []string{K8S}
+	for _, validStoreType := range validStoreTypes {
+		if storeType == validStoreType {
+			return nil
+		}
 	}
 
-	return storeType, nil
+	return log.RecordedError(messages.CSPFK005E, "SECRETS_DESTINATION")
 }

--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -10,13 +12,61 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	Convey("getStoreType", t, func() {
-		Convey("Given an incorrect value for SECRETS_DESTINATION env variable", func() {
-			_, err := getStoreType("incorrect_secrets_destination")
+	Convey("NewFromEnv", t, func() {
+		testNamespace := "test-namespace"
+		testK8sSecrets := "test-k8s-secret,other-k8s-secret, k8s-secret-after-a-space"
+		// remove spaces and split by comma
+		testK8sSecretsList := strings.Split(strings.ReplaceAll(testK8sSecrets, " ", ""), ",")
 
-			Convey("Raises the proper error", func() {
-				So(err.Error(), ShouldEqual, fmt.Sprintf(messages.CSPFK005E, "SECRETS_DESTINATION"))
+		_ = os.Setenv("MY_POD_NAMESPACE", testNamespace)
+		_ = os.Setenv("K8S_SECRETS", testK8sSecrets)
+
+		Convey("Required environment variables exist", func() {
+			Convey("Valid value of SECRETS_DESTINATION", func() {
+				validStoreTypes := []string{K8S}
+				for _, storeType := range validStoreTypes {
+					_ = os.Setenv("SECRETS_DESTINATION", storeType)
+
+					config, err := NewFromEnv()
+					Convey("Doesn't raise an error", func() {
+						So(err, ShouldBeNil)
+					})
+
+					expectedConfig := &Config{
+						PodNamespace:       testNamespace,
+						RequiredK8sSecrets: testK8sSecretsList,
+						StoreType:          storeType,
+					}
+
+					Convey("Returns the expected config", func() {
+						So(config, ShouldResemble, expectedConfig)
+					})
+				}
 			})
+
+			Convey("Invalid value of SECRETS_DESTINATION", func() {
+				_ = os.Setenv("SECRETS_DESTINATION", "invalid_store_type")
+
+				_, err := NewFromEnv()
+				Convey("Raises the proper error", func() {
+					So(err.Error(), ShouldEqual, fmt.Sprintf(messages.CSPFK005E, "SECRETS_DESTINATION"))
+				})
+			})
+		})
+
+		Convey("Missing environment variable", func() {
+			requiredEnvVars := []string{"MY_POD_NAMESPACE", "K8S_SECRETS", "SECRETS_DESTINATION"}
+			for _, requiredEnvVar := range requiredEnvVars {
+				Convey(requiredEnvVar, func() {
+					_ = os.Unsetenv(requiredEnvVar)
+
+					config, err := NewFromEnv()
+					Convey("Raises the proper error", func() {
+						So(config, ShouldBeNil)
+						So(err.Error(), ShouldEqual, fmt.Sprintf(messages.CSPFK004E, requiredEnvVar))
+					})
+				})
+			}
 		})
 	})
 }


### PR DESCRIPTION
Connected to #116 (enhancing code coverage)

Previously we had only one UT for this package and it tested a
private method (which we shouldn't do). This commit removed the
existing UT and added instead UTs for the public method `NewFromEnv`.

It verifies all of its use-cases and has 100% coverage.