### PR TITLE
Skip OC3.10 tests. OC3.10 environment issues.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,9 +51,10 @@ pipeline {
             tasks["Openshift v3.11, oss"] = {
               sh "./bin/test_integration --docker --oss --oc311"
             }
-            tasks["Openshift v3.10, oss"] = {
-              sh "./bin/test_integration --docker --oss --oc310"
-            }
+            //skip oc310 tests until the environment will be ready to use
+            //tasks["Openshift v3.10, oss"] = {
+            //  sh "./bin/test_integration --docker --oss --oc310"
+            //}
           parallel tasks
         }
       }
@@ -69,9 +70,10 @@ pipeline {
             tasks["Openshift v3.11, DAP"] = {
               sh "./bin/test_integration --docker --dap --oc311"
             }
-            tasks["Openshift v3.10, DAP"] = {
-              sh "./bin/test_integration --docker --dap --oc310"
-            }
+           //skip oc310 tests until the environment will be ready to use
+           // tasks["Openshift v3.10, DAP"] = {
+           //   sh "./bin/test_integration --docker --dap --oc310"
+           // }
           parallel tasks
         }
       }


### PR DESCRIPTION
Related to #126 .
It looks like we have issues with oc3.10 environment, need to rebuild the environment and it may take 1-2 days.
Meanwhile we skipped oc3.10 tests. 