### PR TITLE
Remove unused variable MY_POD_IP

### DIFF
--- a/test/config/k8s/test-env.sh.yml
+++ b/test/config/k8s/test-env.sh.yml
@@ -73,11 +73,6 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
 
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-
           - name: CONJUR_APPLIANCE_URL
             value: ${CONJUR_APPLIANCE_URL}
 

--- a/test/config/openshift/test-env.sh.yml
+++ b/test/config/openshift/test-env.sh.yml
@@ -72,11 +72,6 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
 
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-
           - name: CONJUR_APPLIANCE_URL
             value: ${CONJUR_APPLIANCE_URL}
 

--- a/test/demo/pet-store-env.sh.yml
+++ b/test/demo/pet-store-env.sh.yml
@@ -82,11 +82,6 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
 
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-
             - name: CONJUR_APPLIANCE_URL
               value: >-
                 https://conjur-follower.${CONJUR_NAMESPACE_NAME}.svc.cluster.local/api


### PR DESCRIPTION
Connected to #131 

We were declaring the environment variable `MY_POD_IP` but it is not used at any stage of the application process.