### PR TITLE
Pass CONJUR_LOG_LEVEL env var to docker container

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -92,6 +92,7 @@ function runDockerCommand() {
     -i \
     -e UNIQUE_TEST_ID \
     -e CONJUR_APPLIANCE_IMAGE \
+    -e CONJUR_LOG_LEVEL \
     -e CONJUR_FOLLOWER_COUNT \
     -e CONJUR_ACCOUNT \
     -e AUTHENTICATOR_ID \


### PR DESCRIPTION
We have the ability to set CONJUR_LOG_LEVEL in the env so
when we deploy Conjur it will also set the log level of the
DAP cluster to the given level. TO enable this feature in this project
we need to pass the variable in the Docker command to the container
that will run the Conjur deployment
