### PR TITLE
Support CONTAINER_MODE running as an application

### DIFF
--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -33,7 +33,7 @@ spec:
           value: k8s_secrets
 
         - name: CONTAINER_MODE
-          value: init
+          value: application
 
         - name: MY_POD_NAME
           valueFrom:

--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -20,7 +20,7 @@ const CSPFK003E string = "CSPFK003E AccessToken failed to delete access token da
 // Environment variables
 const CSPFK004E string = "CSPFK004E Environment variable '%s' must be provided"
 const CSPFK005E string = "CSPFK005E Provided incorrect value for environment variable %s"
-const CSPFK007E string = "CSPFK007E Setting SECRETS_DESTINATION environment variable to 'k8s_secrets' must run as init container"
+const CSPFK007E string = "CSPFK007E CONTAINER_MODE '%s' is not supported. Supported values are: %v"
 
 // Authenticator
 const CSPFK008E string = "CSPFK008E Failed to instantiate authenticator configuration"


### PR DESCRIPTION
### What does this PR do?
SECRETS_DESTINATION=k8s_secrets was bound to `CONTAINER_MODE=init`. Because we are expanding and supporting the Job flow (and not running as an init container) `CONTAINER_MODE=init` no longer suits our needs. 

In this PR we are introducing a new env variable to support the Job flow (`CONTAINER_MODE=application`)

Logs were approved by Shuli <3

### What ticket does this PR close?
Connected to #166

See image below for example of what will be returned if user inputs a value we don't support
<img width="973" alt="Screen Shot 2020-08-13 at 11 01 47 AM" src="https://user-images.githubusercontent.com/19418506/90109597-bad90e80-dd54-11ea-9f39-3b3916b8d5e1.png">
