### PR TITLE
Add fix for backoff for proper log placement

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -54,7 +54,7 @@ func main() {
 	constantBackOff := backoff.NewConstantBackOff(time.Duration(secretsConfig.RetryIntervalSec) * time.Second)
 	count := 0
 	err = backoff.Retry(func() error {
-		if count > 0 {
+		if count > 0 && err != nil {
 			log.Info(fmt.Sprintf(messages.CSPFK010I, count, secretsConfig.RetryCountLimit))
 		}
 		count++


### PR DESCRIPTION
Previously, the retry loop was printing upon failure. With this fix, the retry log will only be printed if there is a failure

Before:
<img width="839" alt="Screen Shot 2020-08-17 at 4 25 27 PM" src="https://user-images.githubusercontent.com/19418506/90401728-0bc76a80-e0a7-11ea-889d-b63d954540c7.png">

After:
<img width="833" alt="Screen Shot 2020-08-17 at 4 30 38 PM" src="https://user-images.githubusercontent.com/19418506/90401842-36192800-e0a7-11ea-9b96-f6d5f0be9431.png">

