### PR TITLE
Add support for 0 retries for Job

### DIFF
--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -74,7 +74,7 @@ spec:
           value: {{ .Values.environment.conjur.retryIntervalSec | quote }}
         {{- end }}
 
-        {{- if .Values.environment.conjur.retryCountLimit }}
+        {{- if kindIs "float64" .Values.environment.conjur.retryCountLimit }}
         - name: RETRY_COUNT_LIMIT
           value: {{ .Values.environment.conjur.retryCountLimit | quote }}
         {{- end }}


### PR DESCRIPTION
In Helm, zero integer values equate to false so if a user inputs 0, their input will not be taken. This update supports this edge case so that a user can configure a retry limit of 0 so that no retries will take place