### PR TITLE
Fix dev env to take latest tag instead of dev

### DIFF
--- a/deploy/dev/5_load_environment.sh
+++ b/deploy/dev/5_load_environment.sh
@@ -15,7 +15,7 @@ main() {
     create_k8s_secret
     export IMAGE_PULL_POLICY="Never"
     export IMAGE="secrets-provider-for-k8s"
-    export TAG="dev"
+    export TAG="latest"
     deploy_chart
 
     deploy_helm_app

--- a/deploy/dev/reload.sh
+++ b/deploy/dev/reload.sh
@@ -23,7 +23,7 @@ main() {
 
     export IMAGE_PULL_POLICY="Never"
     export IMAGE="secrets-provider-for-k8s"
-    export TAG="dev"
+    export TAG="latest"
     deploy_chart
 
     deploy_helm_app

--- a/deploy/teardown_resources.sh
+++ b/deploy/teardown_resources.sh
@@ -8,9 +8,6 @@ set_namespace $CONJUR_NAMESPACE_NAME
 
 configure_cli_pod
 
-## Helm Chart clean-up
-#rm -f conjur.pem
-
 helm_ci_path="../helm/secrets-provider/ci"
 if [[ "${DEV}" = "false" || "${RUN_IN_DOCKER}" = "true" ]]; then
   helm_ci_path="../../../helm/secrets-provider/ci"


### PR DESCRIPTION
The Secrets Provider Helm Chart json schema only allows version and latest so we need to update the dev tags from dev -> latest 