### PR TITLE
Fix release build to push to DockerHub

### DIFF
--- a/deploy/test/test_in_docker.sh
+++ b/deploy/test/test_in_docker.sh
@@ -31,6 +31,11 @@ buildTestRunnerImage() {
 }
 
 deployConjur() {
+  # Prepare Docker images
+  # This is done outside of the container to avoid authentication errors when pulling from the internal registry
+  # from inside the container
+  docker pull $CONJUR_APPLIANCE_IMAGE
+
   git clone git@github.com:cyberark/kubernetes-conjur-deploy \
       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -115,7 +115,6 @@ runDockerCommand() {
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.config:/root/.config \
-    -v ~/.docker:/root/.docker \
     -v "$PWD/../helm":/helm \
     -v "$PWD":/src \
     -w /src \


### PR DESCRIPTION
When releasing, we were facing a permissions, request to resource denied error. 

The problem originates from `docker login` inside a container and mapping of docker configuration inside a container. The mapping that this PR removes maps the host docker config into the container. This affects the file on the host and the Jenkins user couldn't access the file outside of the container to push the image.
