### PR TITLE
Add batch retrieval solution design

### DIFF
--- a/design/batch_retrieval_design.md
+++ b/design/batch_retrieval_design.md
@@ -7,7 +7,7 @@
 + [Request Body](#request-body)
   - [Headers](#headers)
 + [Response](#response)
-+ [Proposed API vs Old API](#proposed-api-vs-old-api)
++ [Proposed API vs Current API](#proposed-api-vs-current-api)
 + [Permissions](#permissions)
 + [Open questions](#open-questions)
 
@@ -22,6 +22,11 @@ This document will cover the options for enhancing Batch Retrieval requests.
 | Secrets Provider Job Milestone - Solution Design | https://github.com/cyberark/secrets-provider-for-k8s/blob/master/design/milestone_1_2_design_doc.md |
 | Secrets Provider - Feature Doc                   | https://app.zenhub.com/workspaces/palmtree-5d99d900491c060001c85cba/issues/cyberark/secrets-provider-for-k8s/163 |
 
+### References
+
+- https://docs.microsoft.com/en-us/graph/json-batching#first-json-batch-request
+- https://docs.microsoft.com/en-us/graph/json-batching#response-format
+
 ### Motivation
 
 *Previously*, for the init container solution, each Secrets Provider was deployed to the same Pod as the customer application containers. Because of this, when a batch retrieval request was made, the requests were dispersed across many call to the Conjur server. When making the batch retreival request and a permission error occured for example, then the batch request would fail and only that Pod would not spin up successfully. 
@@ -32,9 +37,9 @@ The following table outlines possible solutions to overcome this:
 
 |      | Solution                                                     | Pros                                                         | Cons                                               | Effort (T-shirt size) |
 | ---- | ------------------------------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------- | --------------------- |
-| 1    | *Client side:* <br />For each K8s Secret, perform a new Batch request | - No server side changes / no breaking changes               | Load on server with extra calls (*)                | S, 5 days             |
-| 2    | *Server side:*<br />Update Batch retrieval to return list of variables **and** their response (success/failure) (**) | - Will help us during rotation for Milestone 2<br />- Best practice / straightforward design for batch endpoint | - Requires both client/server implementation<br /> | M, 10 days            |
-| 3    | Stay as is                                                   | No additional work needed                                    | - Bad UX<br />- Performance issues                 | -                     |
+| 1    | *Client side:* <br />For each K8s Secret, perform a new Batch request | - No server side changes                                     | Load on server with extra calls (*)                | S, 5 days             |
+| 2    | *Server side:*<br />Update Batch retrieval to return list of variables **and** their individual responses (success/failure) (**) | - Best practice / straightforward design for batch endpoint<br />- Will help us during rotation for Milestone 2<br /> | - Requires both client/server implementation<br /> | M, 10 days            |
+| 3    | Stay as is                                                   | No additional work needed                                    | - Bad UX<br />                                     | -                     |
 
 (*) Fallback solution: use this solution as a safety net, only if the original Batch Retrieval request fails
 
@@ -43,47 +48,41 @@ The following table outlines possible solutions to overcome this:
 *Decision:* We decided to go with #2 and create our own API. We decided to create a new batch retrieval API because of the following reasons:
 
 1. Adding onto the existing batch endpoint would lead to changing behaviors for our needs in the Secrets Provider which would have cascading impacts on other teams. 
-2. The two APIs (current and new) offer separate use-cases;  partial success (new) and fail fast (old)
-3. The old batch retrieval API accepts variable IDs as query parameters. We anticipate a long string of variableIDs to be passed in for secret retrieval and this impacts performance.
+2. The two APIs (current and new) offer separate use-cases;  partial success (new) and fail fast (current)
+3. The current batch retrieval API accepts variable IDs as query parameters. We anticipate a long string of variableIDs to be passed in for secret retrieval and this impacts performance.
 4. Query parameters for HTTP GET requests are limited in length (2,048 characters) which is problematic if a customer has long secrets paths.
 5. The new route offers is more useful if we choose to expand its functionality in the future. By using POST instead of GET we can not only opt to use query parameters but also utilize the body of the request.
 
+At this stage this new batch retrieval API endpoint will be for internal use only.
+
 ### Design
 
-#### Secrets Provider Job flow
+#### Secrets Provider init container flow
 
-As a small recap, the following explains the Secrets Provider Job flow
+As a small recap, the following explains the Secrets Provider init container flow
 
-1. The `cyberark-secrets-provider-for-k8s` runs as a Job and authenticates with the Conjur/DAP Follower using the Kubernetes Authenticator (`authn-k8s`).
+1. The `cyberark-secrets-provider-for-k8s` runs as an init container and authenticates with the Conjur/DAP Follower using the Kubernetes Authenticator (`authn-k8s`).
 
 2. The `cyberark-secrets-provider-for-k8s` reads all Kubernetes secrets required by the applications in the same namespace.
 
-3. For each mapped Kubernetes secret, 
+3. For each mapped Kubernetes secret, the `cyberark-secrets-provider-for-k8s` 
 
-   a. The `cyberark-secrets-provider-for-k8s` performs a Batch Retrieval request and retrieves Conjur/DAP secrets.
+   a. Performs a Batch Retrieval request and retrieves Conjur/DAP secrets.
 
-   b. It updates the Kubernetes secret with the Conjur/DAP secret value.
+   b. Updates the Kubernetes secret with the Conjur/DAP secret value.
 
-4. The `cyberark-secrets-provider-for-k8s` Job is completed.
+4. The `cyberark-secrets-provider-for-k8s` init container runs to completion.
 
 The new Batch Retrieval API will effect #2a. 
 
 ### URI
 
-##### POST /secrets/batch
+##### POST /secrets/batch/v2
 
-This method retuns a list of secrets, their status code, and their value if an error did not occur. See difference between proposed API and existing API see [Proposed API vs Old API](#proposed-api-vs-old-api) below.
+This method retuns a list of secrets, their status code, and their value if an error did not occur. For differences between proposed API and existing API see [Proposed API vs Current API](#proposed-api-vs-current-api) section below.
 
 ```
-POST /secrets/batch
-
-{
-  "variables": [
-    {"name": "var/path/conjurSecret"},
-    {"name": "var/path/anotherConjurSecret"},
-    ...
-  ]
-}
+POST /secrets/batch/v2
 ```
 
 ### Request Body
@@ -93,8 +92,8 @@ The request body is a list of all variable IDs (paths to secrets in Conjur/DAP) 
 ```
 {
   "variables": [
-    {"name": "var/path/conjurSecret"},
-    {"name": "var/path/anotherConjurSecret"},
+    {"id": "var/path/conjurSecret"},
+    {"id": "var/path/anotherConjurSecret"},
     ...
   ]
 }
@@ -111,73 +110,108 @@ Authorization: Token token="eyJkYX...Rhb="
 
 #### Batch Response
 
-If no Conjur/DAP secrets were able to be retrieved (no 200 code), the response will still return a 200 OK because the [request body is parsable]([https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The%20status%20code%20on%20a,requests%20inside%20the%20batch%20succeeded](https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The status code on a,requests inside the batch succeeded)) and request was handled.
+```
+# Headers
+HTTP/1.1
+Content-Type: application/json
 
-If an invalid request body was supplied, a 400 Bad Request will be returned
+# Status response code
+200 OK
+
+# Body
+{
+  "variables": [
+  {
+    "id": "var/path/name1",
+    "status": 200,
+    "value": "superSecret"
+  },
+  {
+    "id": "var/path/name2",
+    "status": 403
+    "error": {
+      "message": "Forbidden"
+    }
+  },
+  {
+    "id": "var/path/name3",
+    "status": 404
+    "error": {
+      "message": "Not Found"
+ 		}
+  },
+  {
+    "id": "var/path/name4",
+    "status": 200
+    "value": "superSuperSecret"    
+  }
+ ]
+}
+```
 
 | Code            | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
 | 200 OK          | All secret values were retrieved successfully                |
-| 400 Bad Request | Server cannot process request due to client error (invalid input parameters or logical validations) |
+| 400 Bad Request | Server cannot process request due to client error (unparsable request body) |
 
-#### Individual secret responses
+If no Conjur/DAP secrets were able to be retrieved, the response will still return a 200 OK because the [request body is parsable]([https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The%20status%20code%20on%20a,requests%20inside%20the%20batch%20succeeded](https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The status code on a,requests inside the batch succeeded)) and request was handled.
 
-All secret values will be treated as individual entities. If a single secret fails to be retrieved, this will not impact the integrity of the request. Each secret has it's own response code.
+If an invalid request body was supplied, a 400 Bad Request will be returned.
 
-| Code             | Description                                                  |
+#### Response body
+
+All secret values will be treated as individual entities. If a single secret fails to be retrieved, this will ***not*** impact the integrity of the request. Each secret has it's own response code. 
+
+| Parameter     | Description                                        |
+| ------------- | -------------------------------------------------- |
+| id            | ID for Conjur/DAP variable                         |
+| value         | Secret for variable ID                             |
+| error.status  | Response status code of the error. See table below |
+| error.message | Response message of the error. See table below     |
+
+##### Individual secret responses
+
+The following are the possible error codes that can be returned for individual secrets.
+
+| Status/Message   | Description                                                  |
 | ---------------- | ------------------------------------------------------------ |
-| 200 OK           | All secret values were retrieved successfully                |
-| 400 Bad Request  | Server cannot process request due to client error (invalid input parameters or logical validations) |
+| 400 Bad Request  | Server cannot process request due to client error (invalid input parameters or logical validations). For example: adding `<>` in path to secret in Conjur/DAP |
 | 401 Unauthorized | The request lacks valid authentication credentials           |
 | 403 Forbidden    | The authenticated user lacks the necessary privilege         |
 | 404 Not Found    | Variable does not exist or variable does not have secret value |
 
-#### Example response
+### Proposed API vs Current API
 
-```
-HTTP/1.1 200 OK
-
-{
-  "variables": [
-  	{
-      "name": "var/path/name1",
-      "status": 200,
-      "value": "superSecret"
-    },
-    {
-      "name": "var/path/name2",
-      "status": 403,
-      "value": "Forbidden"     
-    },
-		  "name": "var/path/name3",
-      "status": 404,
-      "value": "Not Found"    
-    },
-    {
-      "name": "var/path/name4",
-      "status": 200,
-      "value": "superSuperSecret"    
-    }
-  ]
-}
-```
-
-### Proposed API vs Old API
-
-|               | Old                                                          | Proposed                                                   |
-| ------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
-| URI           | `GET /secrets{?variable_ids}}`                               | `POST /secrets/batch`                                      |
-| Request Body  | -                                                            | See **Request Body** section                               |
-| Response Body | JSON of ***only*** successfully retrieved secrets and their values | JSON of **all** secrets, the status code, and their values |
-| Behavior      | Request fails when individual request fails                  | Request does not fail when sub/individual requests fail    |
+|               | Current                                                      | Proposed                                                     |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| URI           | `GET /secrets{?variable_ids}}`                               | `POST /secrets/batch/v2`                                     |
+| Request Body  | -                                                            | See **Request Body** section                                 |
+| Response Body | JSON of ***only*** successfully retrieved secrets and their values. Single failure, fails whole request and no secret is returned. | JSON of **all** secrets, their status code/messages, and values for successfully retrieved secrets |
+| Behavior      | Request fails when individual request fails                  | Request does not fail when sub/individual requests fail      |
 
 ### Permissions
 
-Only an authorized Host with `read` and `execute` privileges on the Conjur/DAP secrets will be able to fetch the secret values. Otherwise, the proper 403 Forbidden error code will be returned for `status` and `value` of the response respectively. 
+Only an authorized Host with `read` and `execute` privileges on the Conjur/DAP secrets will be able to fetch the secret values. Otherwise, the proper 403 Forbidden error code will be returned for `status` and `message` of the response respectively. 
 
 During configuration of the Secrets Provider, the Host detailed for `authnLogin` is the Host that the Secrets Provider will use to authenticate to Conjur/DAP Follower and retrieve Conjur/DAP secrets. Therefore, this is the Host that will be used to make the request to this new Batch API endpoint and retrieve secrets from Conjur/DAP.
 
+### Mitigation
+
+Now that it is easy to brute-force multiple variables at a time in the body of the request, we should implement the necessary mitigations to close the attack surface.
+
+### Audit
+
+A new audit entry will made per secret fetched from Conjur/DAP as is done in the current Batch retrieval API endpoint.
+
 ### Open questions
 
-1. Do we want this duplicated API documented? 
+1. Do we want this duplicated API documented? At this stage this API endpoint will be for internal use only.
 2. Do we ultimately want to move to a single Batch Request API and depricate the existing one?
+
+### Future enhancements
+
+The following are ideas for possible extension of the batch retrieval endpoint API and not necessary directly related to the Secrets Provider project.
+
+1. Add secret versions as a filtering query parameter so we can get all secrets after a certain version
+2. Fetch all secrets that the user/host has permissions to
+3. Fetch all secrets after `/var/path/*` that the user/host has permissions to

--- a/design/batch_retrieval_design.md
+++ b/design/batch_retrieval_design.md
@@ -1,20 +1,183 @@
 # Batch retrieval design
 
++ [Useful Links](#useful-links)
++ [Motivation](#motivation)
++ [Design](#design)
++ [URI](#uri)
++ [Request Body](#request-body)
+  - [Headers](#headers)
++ [Response](#response)
++ [Proposed API vs Old API](#proposed-api-vs-old-api)
++ [Permissions](#permissions)
++ [Open questions](#open-questions)
+
 This document will cover the options for enhancing Batch Retrieval requests.
+
+
+
+### Useful Links
+
+| Name                                             | Link                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------ |
+| Secrets Provider Job Milestone - Solution Design | https://github.com/cyberark/secrets-provider-for-k8s/blob/master/design/milestone_1_2_design_doc.md |
+| Secrets Provider - Feature Doc                   | https://app.zenhub.com/workspaces/palmtree-5d99d900491c060001c85cba/issues/cyberark/secrets-provider-for-k8s/163 |
 
 ### Motivation
 
-*Previously*, for the init container solution, each Secrets Provider was sitting within the same Deployment as the app. Because of this, when a batch retrieval request was made, the requests were dispersed across many call to the Conjur server. If one K8s Secret was not able to be updated with a Conjur value (for example due to a permission error), then the batch request would fail and only that pod would not spin up successfully. 
+*Previously*, for the init container solution, each Secrets Provider was deployed to the same Pod as the customer application containers. Because of this, when a batch retrieval request was made, the requests were dispersed across many call to the Conjur server. When making the batch retreival request and a permission error occured for example, then the batch request would fail and only that Pod would not spin up successfully. 
 
-*Now* that the Secrets Provider is outside, a single batch retrieval request will be made to Conjur for *all* application. So if there is a failure in receiving one of the values, then the whole request would fail. In other words, **no application** will spin up in the namespace.
+*Now*, with the Job Milestone, the Secrets Provider is deployed outside of the customers' Pods, supporting multiple customer pods. With this, a single batch retrieval request will be made for *all* applications to fetch the necessary secrets to deploy properly. Therefore, if there is a failure in receiving one of the values, then the whole request will fail. In other words, **no application** Pod will spin up in the namespace. This leads to a faulty user experience.
 
-|      | Solution                                                     | Pros                                                         | Cons                                                         | Effort (T-shirt size) |
-| ---- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------- |
-| 1    | *Client side:* <br />For each K8s Secret, perform a new Batch request | - No server side changes / no breaking changes               | Load on server with extra calls (*)                          | S, 5 days             |
-| 2    | *Server side:*<br />Update Batch retrieval to return list of variables **and** their response (success/failure) (**) | - Will help us during rotation for Milestone 2<br />- Better / straightforward design for how batch endpoints | - Requires both client/server implementation<br />- Need to handle backwards compatibility | M, 10 days            |
-| 3    | Stay as is                                                   | No additional work needed                                    | Bad UX                                                       | -                     |
+The following table outlines possible solutions to overcome this:
+
+|      | Solution                                                     | Pros                                                         | Cons                                               | Effort (T-shirt size) |
+| ---- | ------------------------------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------- | --------------------- |
+| 1    | *Client side:* <br />For each K8s Secret, perform a new Batch request | - No server side changes / no breaking changes               | Load on server with extra calls (*)                | S, 5 days             |
+| 2    | *Server side:*<br />Update Batch retrieval to return list of variables **and** their response (success/failure) (**) | - Will help us during rotation for Milestone 2<br />- Best practice / straightforward design for batch endpoint | - Requires both client/server implementation<br /> | M, 10 days            |
+| 3    | Stay as is                                                   | No additional work needed                                    | - Bad UX<br />- Performance issues                 | -                     |
 
 (*) Fallback solution: use this solution as a safety net, only if the original Batch Retrieval request fails
 
 (**) This solution can be broken up in two: 1. Create a new API endpoint or 2. use existing one (return 409 response)
 
+*Decision:* We decided to go with #2 and create our own API. We decided to create a new batch retrieval API because of the following reasons:
+
+1. Adding onto the existing batch endpoint would lead to changing behaviors for our needs in the Secrets Provider which would have cascading impacts on other teams. 
+2. The two APIs (current and new) offer separate use-cases;  partial success (new) and fail fast (old)
+3. The old batch retrieval API accepts variable IDs as query parameters. We anticipate a long string of variableIDs to be passed in for secret retrieval and this impacts performance.
+4. Query parameters for HTTP GET requests are limited in length (2,048 characters) which is problematic if a customer has long secrets paths.
+5. The new route offers is more useful if we choose to expand its functionality in the future. By using POST instead of GET we can not only opt to use query parameters but also utilize the body of the request.
+
+### Design
+
+#### Secrets Provider Job flow
+
+As a small recap, the following explains the Secrets Provider Job flow
+
+1. The `cyberark-secrets-provider-for-k8s` runs as a Job and authenticates with the Conjur/DAP Follower using the Kubernetes Authenticator (`authn-k8s`).
+
+2. The `cyberark-secrets-provider-for-k8s` reads all Kubernetes secrets required by the applications in the same namespace.
+
+3. For each mapped Kubernetes secret, 
+
+   a. The `cyberark-secrets-provider-for-k8s` performs a Batch Retrieval request and retrieves Conjur/DAP secrets.
+
+   b. It updates the Kubernetes secret with the Conjur/DAP secret value.
+
+4. The `cyberark-secrets-provider-for-k8s` Job is completed.
+
+The new Batch Retrieval API will effect #2a. 
+
+### URI
+
+##### POST /secrets/batch
+
+This method retuns a list of secrets, their status code, and their value if an error did not occur. See difference between proposed API and existing API see [Proposed API vs Old API](#proposed-api-vs-old-api) below.
+
+```
+POST /secrets/batch
+
+{
+  "variables": [
+    {"name": "var/path/conjurSecret"},
+    {"name": "var/path/anotherConjurSecret"},
+    ...
+  ]
+}
+```
+
+### Request Body
+
+The request body is a list of all variable IDs (paths to secrets in Conjur/DAP) that need to be retrieved. For example: 
+
+```
+{
+  "variables": [
+    {"name": "var/path/conjurSecret"},
+    {"name": "var/path/anotherConjurSecret"},
+    ...
+  ]
+}
+```
+
+#### Headers
+
+```
+Content-Type: application/json
+Authorization: Token token="eyJkYX...Rhb="
+```
+
+### Response
+
+#### Batch Response
+
+If no Conjur/DAP secrets were able to be retrieved (no 200 code), the response will still return a 200 OK because the [request body is parsable]([https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The%20status%20code%20on%20a,requests%20inside%20the%20batch%20succeeded](https://docs.microsoft.com/en-us/graph/json-batching#:~:text=The status code on a,requests inside the batch succeeded)) and request was handled.
+
+If an invalid request body was supplied, a 400 Bad Request will be returned
+
+| Code            | Description                                                  |
+| --------------- | ------------------------------------------------------------ |
+| 200 OK          | All secret values were retrieved successfully                |
+| 400 Bad Request | Server cannot process request due to client error (invalid input parameters or logical validations) |
+
+#### Individual secret responses
+
+All secret values will be treated as individual entities. If a single secret fails to be retrieved, this will not impact the integrity of the request. Each secret has it's own response code.
+
+| Code             | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| 200 OK           | All secret values were retrieved successfully                |
+| 400 Bad Request  | Server cannot process request due to client error (invalid input parameters or logical validations) |
+| 401 Unauthorized | The request lacks valid authentication credentials           |
+| 403 Forbidden    | The authenticated user lacks the necessary privilege         |
+| 404 Not Found    | Variable does not exist or variable does not have secret value |
+
+#### Example response
+
+```
+HTTP/1.1 200 OK
+
+{
+  "variables": [
+  	{
+      "name": "var/path/name1",
+      "status": 200,
+      "value": "superSecret"
+    },
+    {
+      "name": "var/path/name2",
+      "status": 403,
+      "value": "Forbidden"     
+    },
+		  "name": "var/path/name3",
+      "status": 404,
+      "value": "Not Found"    
+    },
+    {
+      "name": "var/path/name4",
+      "status": 200,
+      "value": "superSuperSecret"    
+    }
+  ]
+}
+```
+
+### Proposed API vs Old API
+
+|               | Old                                                          | Proposed                                                   |
+| ------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| URI           | `GET /secrets{?variable_ids}}`                               | `POST /secrets/batch`                                      |
+| Request Body  | -                                                            | See **Request Body** section                               |
+| Response Body | JSON of ***only*** successfully retrieved secrets and their values | JSON of **all** secrets, the status code, and their values |
+| Behavior      | Request fails when individual request fails                  | Request does not fail when sub/individual requests fail    |
+
+### Permissions
+
+Only an authorized Host with `read` and `execute` privileges on the Conjur/DAP secrets will be able to fetch the secret values. Otherwise, the proper 403 Forbidden error code will be returned for `status` and `value` of the response respectively. 
+
+During configuration of the Secrets Provider, the Host detailed for `authnLogin` is the Host that the Secrets Provider will use to authenticate to Conjur/DAP Follower and retrieve Conjur/DAP secrets. Therefore, this is the Host that will be used to make the request to this new Batch API endpoint and retrieve secrets from Conjur/DAP.
+
+### Open questions
+
+1. Do we want this duplicated API documented? 
+2. Do we ultimately want to move to a single Batch Request API and depricate the existing one?

--- a/design/batch_retrieval_design.md
+++ b/design/batch_retrieval_design.md
@@ -288,7 +288,31 @@ The following integration tests will be implemented in Secrets Provider for K8s
 
 ## Performance tests
 
---
+The following performance tests will be run using *Jmeter*.
+These tests will be run for both the new API and the existing one, and compare the results between them.
+
+#### Benchmark
+
+| Section     | Parameter                      | Value          |
+| ----------- | ------------------------------ | -------------- |
+| Conjur      | \# of standbys                 | 2              |
+| Conjur      | \# of followers                | 1              |
+| Environment | Kubernetes                     | OpenShift 3.11 |
+| Environment | \# of cores                    | 16             |
+| Environment | \# of nodes                    | 1              |
+| Test        | \# of requesting threads       | 20             |
+| Test        | \# of variables                | 1025           |
+| Test        | \# of variabels per policy     | 5              |
+| Test        | \# of policies                 | 205            |
+| Test        | Variable ID length             | 50             |
+| Test        | Variable value length (secret) | 50             |
+
+
+
+|      | Scenario      | Given                                                        | When                                                         | Then                                                         | Manual/Automated |
+| ---- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ---------------- |
+| 1    | Response time | - Conjur is running<br />- Host is defined<br />- 1024 Secrets are defined<br /> | For X=1, X<=1024, X=X\*2:<br />    Concurrently retrieve X secrets for 5 minutes, measure average response time.<br />    Repeat each step 3 times.<br /> | Calculate the average response time between the 3 cycles for each step.<br />Plot the average response time per number of secrets provider. | Manual           |
+| 2    | Throughput    | - Conjur is running<br />- Host is defined<br />- 1024 Secrets are defined<br /> | For X=1, X<=1024, X=X\*2:<br />    Concurrently retrieve X secrets for 5 minutes, measure throughput.<br />    Repeat each step 3 times.<br /> | Calculate the throughput between the 3 cycles for each step.<br />Plot the throughput per number of secrets provider. | Manual           |
 
 
 
@@ -308,19 +332,20 @@ The following are ideas for possible extension of the batch retrieval endpoint A
 
 ### Delivery Plan
 
-- [ ] Fix flaky tests *2 days*
-- [ ] Implement new API endpoint in Conjur *5 days*
-- [ ] Add integration tests in Conjur *4 days*
+- [ ] Fix flaky tests ***2 days***
+- [ ] Implement new API endpoint in Conjur ***5 days***
+- [ ] Add integration tests in Conjur ***4 days***
 - [ ] Golang SDK
-  - [ ] Implement batch logic *2 days*
-  - [ ] Add unit tests *2 days*
-- [ ] Implement change in Secrets Provider *3 days*
+  - [ ] Implement batch logic ***2 days***
+  - [ ] Add unit tests ***2 days***
+- [ ] Implement change in Secrets Provider ***3 days***
 - [ ] Implement test plan
-  - [ ] Add integration tests in Secrets Provider *3 days*
+  - [ ] Add integration tests in Secrets Provider ***3 days***
 - [ ] Performance tests
-  - [ ] In Conjur *TBD*
-  - [ ] In Secrets Provider *TBD*
-- [ ] Team/cross-team review cycle *3 days*
-- [ ] Logs reviewed by TW *1 day*
+  - [ ] In Conjur ***5 days***
+  - [ ] In Secrets Provider ***3 days***
+- [ ] Team/cross-team review cycle ***3 days***
+- [ ] Logs reviewed by TW ***1 day***
 
-Total: 29 days ~6 weeks
+Total: 33 days ~6.5 weeks
+


### PR DESCRIPTION
### What does this PR do?
Add solution design for new batch retrieval API endpoint

### Background
*Previously*, for the init container solution, each Secrets Provider was deployed to the same Pod as the customer application containers. Because of this, when a batch retrieval request was made, the requests were dispersed across many call to the Conjur server. When making the batch retreival request and a permission error occured for example, then the batch request would fail and only that Pod would not spin up successfully. 

*Now*, with the Job Milestone, the Secrets Provider is deployed outside of the customers' Pods, supporting multiple customer pods. With this, a single batch retrieval request will be made for *all* applications to fetch the necessary secrets to deploy properly. Therefore, if there is a failure in receiving one of the values, then the whole request will fail. In other words, **no application** Pod will spin up in the namespace. This leads to a faulty user experience.

### What ticket does this PR close?
Connected to -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation