### PR TITLE
Update container name to cyberark-secrets-provider-for-k8s

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Run `kubectl config use-context docker-desktop` to switch to a local context. Th
 
 1. Run `./bin/start --dev`, appending `--oss` or `--dap` according to the environment that needs to be deployed
 
-1. To view the pod(s) that were deployed and the Secrets Provider logs, run `kubectl get pods` and `kubectl logs <pod-name> -c cyberark-secrets-provider` respectively. 
+1. To view the pod(s) that were deployed and the Secrets Provider logs, run `kubectl get pods` and `kubectl logs <pod-name> -c cyberark-secrets-provider-for-k8s` respectively. 
 You can also view Conjur/DAP pod logs by running `kubectl get pods -n local-conjur` and `kubectl logs <conjur-pod-name> -n local-conjur`
 
 1. If a cluster is already locally deployed run `./bin/start --dev --reload` to build your local changes and redeploy them to the local Secrets Provider K8s cluster

--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -59,7 +59,7 @@ spec:
       initContainers:
       - image: '${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
         imagePullPolicy: Always
-        name: cyberark-secrets-provider
+        name: cyberark-secrets-provider-for-k8s
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -58,7 +58,7 @@ spec:
       initContainers:
       - image: '${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
         imagePullPolicy: Always
-        name: cyberark-secrets-provider
+        name: cyberark-secrets-provider-for-k8s
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -49,7 +49,7 @@ spec:
       initContainers:
       - image: 'secrets-provider-for-k8s:latest'
         imagePullPolicy: Never
-        name: cyberark-secrets-provider
+        name: cyberark-secrets-provider-for-k8s
         env:
           - name: CONTAINER_MODE
             value: init

--- a/deploy/policy/templates/authn-any-policy-branch.template.sh.yml
+++ b/deploy/policy/templates/authn-any-policy-branch.template.sh.yml
@@ -20,7 +20,7 @@ cat << EOL
       - !host
         id: ${APP_NAMESPACE_NAME}/*/*
         annotations:
-          kubernetes/authentication-container-name: cyberark-secrets-provider
+          kubernetes/authentication-container-name: cyberark-secrets-provider-for-k8s
 
       # This host tests the ability to authenticate hosts with application identity in annotations
       - !host
@@ -28,7 +28,7 @@ cat << EOL
         annotations:
           authn-k8s/namespace: ${APP_NAMESPACE_NAME}
           authn-k8s/service-account: ${APP_NAMESPACE_NAME}-sa
-          authn-k8s/authentication-container-name: cyberark-secrets-provider
+          authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
 
     - !grant
       role: !layer
@@ -38,7 +38,7 @@ cat << EOL
 - !host
   id: ${APP_NAMESPACE_NAME}/*/*
   annotations:
-    kubernetes/authentication-container-name: cyberark-secrets-provider
+    kubernetes/authentication-container-name: cyberark-secrets-provider-for-k8s
 
 # Add the root based host to the "some-apps" layer so we can give it permissions easily
 - !grant

--- a/deploy/policy/templates/conjur-authn-k8s.template.sh.yml
+++ b/deploy/policy/templates/conjur-authn-k8s.template.sh.yml
@@ -17,13 +17,13 @@ cat << EOL
       - !host
         id: ${APP_NAMESPACE_NAME}/*/*
         annotations:
-          kubernetes/authentication-container-name: cyberark-secrets-provider
+          kubernetes/authentication-container-name: cyberark-secrets-provider-for-k8s
 
       # This host will not have permissions on Conjur secrets to test this use-case
       - !host
         id: ${APP_NAMESPACE_NAME}/service_account/${APP_NAMESPACE_NAME}-sa
         annotations:
-          kubernetes/authentication-container-name: cyberark-secrets-provider
+          kubernetes/authentication-container-name: cyberark-secrets-provider-for-k8s
 
     - !grant
       role: !layer

--- a/deploy/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
+++ b/deploy/test/test_cases/TEST_ID_10_SECRETS_DESTINATION_not_exist.sh
@@ -12,4 +12,4 @@ deploy_init_env
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable 'SECRETS_DESTINATION' must be provided'"
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004E"

--- a/deploy/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/deploy/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error CAKC015E Login failed"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CAKC015E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CAKC015E"

--- a/deploy/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/deploy/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error CSPFK034E Failed to retrieve Conjur secrets"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK034E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK034E"

--- a/deploy/test/test_cases/TEST_ID_24_helm_validate_K8S_SECRETS_env_var_incorrect_value.sh
+++ b/deploy/test/test_cases/TEST_ID_24_helm_validate_K8S_SECRETS_env_var_incorrect_value.sh
@@ -18,7 +18,7 @@ popd
 
 echo "Expecting Secrets Provider to fail with debug message 'CSPFK004D Failed to retrieve k8s secret. Reason: secrets K8S_SECRET-non-existent-secret not found'"
 pod_name=$($cli_with_timeout get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-helm --no-headers | awk '{print $1}' )
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004D"
 
 echo "Expecting Secrets Provider to fail with error 'CSPFK020E Failed to retrieve k8s secret'"
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK020E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK020E"

--- a/deploy/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
+++ b/deploy/test/test_cases/TEST_ID_3_SECRETS_DESTINATION_with_incorrect_value.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005E Provided incorrect value for environment variable SECRETS_DESTINATION'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK005E"

--- a/deploy/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
+++ b/deploy/test/test_cases/TEST_ID_4_CONTAINER_MODE_not_exist.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK007E Setting SECRETS_DESTINATION environment variable to 'k8s_secrets' must run as init container'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK007E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK007E"

--- a/deploy/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
+++ b/deploy/test/test_cases/TEST_ID_5_no_get_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK004D Failed to retrieve k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004D"

--- a/deploy/test/test_cases/TEST_ID_6_no_update_permission_to_secret.sh
+++ b/deploy/test/test_cases/TEST_ID_6_no_update_permission_to_secret.sh
@@ -11,4 +11,4 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with error 'CSPFK005D Failed to update k8s secret. Reason:...'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK005D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK005D"

--- a/deploy/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
+++ b/deploy/test/test_cases/TEST_ID_7_K8S_SECRETS_env_var_not_exist.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004E"

--- a/deploy/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
+++ b/deploy/test/test_cases/TEST_ID_8_K8S_SECRETS_env_var_empty.sh
@@ -14,4 +14,4 @@ wait_for_it 600 "cli_get_pods_test_env | grep CrashLoopBackOff"
 
 echo "Expecting Secrets provider to fail with error 'CSPFK004E Environment variable K8S_SECRETS must be provided'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004E"

--- a/deploy/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
+++ b/deploy/test/test_cases/TEST_ID_9_K8S_SECRETS_env_var_incorrect_value.sh
@@ -11,7 +11,7 @@ deploy_init_env
 
 echo "Expecting secrets provider to fail with debug message 'CSPFK004D Failed to retrieve k8s secret. Reason: secrets K8S_SECRETS_invalid_value not found'"
 pod_name=$(cli_get_pods_test_env | awk '{print $1}')
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK004D"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK004D"
 
 echo "Expecting secrets provider to fail with error 'CSPFK020E Failed to retrieve k8s secret'"
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider | grep CSPFK020E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CSPFK020E"

--- a/helm/secrets-provider/ci/take-image-values-template.yaml
+++ b/helm/secrets-provider/ci/take-image-values-template.yaml
@@ -2,4 +2,4 @@ secretsProvider:
   image: {{ IMAGE }}
   imagePullPolicy: {{ IMAGE_PULL_POLICY }}
   tag: {{ TAG }}
-  name: cyberark-secrets-provider
+  name: cyberark-secrets-provider-for-k8s

--- a/helm/secrets-provider/ci/test-values-template.yaml
+++ b/helm/secrets-provider/ci/test-values-template.yaml
@@ -14,7 +14,7 @@ secretsProvider:
   image: {{ IMAGE }}
   imagePullPolicy: {{ IMAGE_PULL_POLICY }}
   tag: {{ TAG }}
-  name: cyberark-secrets-provider
+  name: cyberark-secrets-provider-for-k8s
 
 # Additional labels to apply to all resources.
 labels: { {{ LABELS }} }

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -14,7 +14,7 @@ secretsProvider:
   image: cyberark/secrets-provider-for-k8s
   tag: 1.1.0
   imagePullPolicy: IfNotPresent
-  name: cyberark-secrets-provider
+  name: cyberark-secrets-provider-for-k8s
 
 # OPTIONAL: Additional labels to apply to Job resource.
 labels: {}


### PR DESCRIPTION
### Motivation

As part of the documentation effort, we need to align on how we reference the Secrets Provider init/application container. We agreed on `cyberark-secrets-provider-for-k8s` in-place of `cyberark-secrets-provider`". This demands changes in both our helm charts and our test suite. 

### What ticket does this PR close?
Connected to -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes
Updates naming in tests as well

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs. Shuli is on it