### PR TITLE
Add microseconds to logs time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Improve log messages to include also microseconds instead of only seconds.
 
 ## [1.1.0] - 2020-08-20
 ### Added

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -8,8 +8,8 @@ import (
 	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
 )
 
-var stdoutLogger = log.New(os.Stdout, "INFO:  ", log.LUTC|log.Ldate|log.Ltime|log.Lshortfile)
-var errorLogger = log.New(os.Stderr, "ERROR: ", log.LUTC|log.Ldate|log.Ltime|log.Lshortfile)
+var stdoutLogger = log.New(os.Stdout, "INFO:  ", log.LUTC|log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
+var errorLogger = log.New(os.Stderr, "ERROR: ", log.LUTC|log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
 var isDebug = false
 
 /*


### PR DESCRIPTION
### What does this PR do?
Since secrets provider operation can be finished in less than a second, logs time resolution of seconds is not enough to understand steps duration.
Adding microseconds to logs time resolution allow better investigation of steps duration.

### What ticket does this PR close?
Connected to #221

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation

