### PR TITLE
Rebump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2020-09-15
 ### Added
 - Helm chart to deploy the Secrets Provider Job using Helm ([cyberark/secrets-provider-for-k8s#165](https://github.com/cyberark/secrets-provider-for-k8s/pulls/165))
 - CONTAINER_MODE support for application containers in addition to init containers ([cyberark/secrets-provider-for-k8s#179](https://github.com/cyberark/secrets-provider-for-k8s/pull/179))

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -8,7 +8,7 @@ of the license associated with each component.
 
 Section 1: Apache-2.0
 >>> github.com/cyberark/conjur-api-go - v0.6.0
->>> github.com/cyberark/conjur-authn-k8s-client - v0.16.1
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.18.1
 >>> github.com/googleapis/gnostic - v0.3.1
 >>> github.com/modern-go/reflect2 - v1.0.1
 >>> gopkg.in/yaml.v2 - v2.3.0
@@ -23,7 +23,6 @@ Section 2: BSD 3-Clause
 >>> golang.org/x/oauth2 - v0.0.0-20191202225959-858c2ad4c8b6
 >>> golang.org/x/time - v0.0.0-20191024005414-555d28b269f0
 >>> gopkg.in/inf.v0 - v0.9.1
->>> sigs.k8s.io/yaml - v1.1.0
 
 Section 3: MIT
 >>> github.com/cenkalti/backoff - v2.2.1
@@ -44,7 +43,7 @@ Apache-2.0 License is applicable to the following component(s).
 
 >>> github.com/cyberark/conjur-api-go - v0.6.0
 
-Copyright 2017 CyberArk Software, Inc
+Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,7 +57,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/cyberark/conjur-authn-k8s-client - v0.16.1
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.18.1
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
@@ -76,7 +75,7 @@ limitations under the License.
 
 >>> github.com/googleapis/gnostic - v0.3.1
 
-Copyright [yyyy] [name of copyright owner]
+Copyright Google LLC 2017-2020
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,8 +91,6 @@ limitations under the License.
 
 >>> github.com/modern-go/reflect2 - v1.0.1
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -108,7 +105,7 @@ limitations under the License.
 
 >>> gopkg.in/yaml.v2 - v2.3.0
 
-Copyright {yyyy} {name of copyright owner}
+Copyright 2011-2016 Canonical Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -124,7 +121,7 @@ limitations under the License.
 
 >>> k8s.io/api - v0.0.0-20190313235455-40a48860b5ab
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright 2016-2018 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -140,7 +137,7 @@ limitations under the License.
 
 >>> k8s.io/apimachinery - v0.0.0-20190313205120-d7deff9243b1
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright 2016 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -156,7 +153,7 @@ limitations under the License.
 
 >>> github.com/kubernetes/client-go - v11.0.0
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright 2020 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -172,7 +169,7 @@ limitations under the License.
 
 >>> github.com/kubernetes/klog - v1.0.0
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright 2020 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -188,7 +185,7 @@ limitations under the License.
 
 >>> k8s.io/utils - v0.0.0-20191218082557-f07c713de883
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2017 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -335,36 +332,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
->>> sigs.k8s.io/yaml - v1.1.0
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------- SECTION 3: MIT ----------
 
@@ -461,6 +428,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 =============== APPENDIX: License Files and Templates ==============


### PR DESCRIPTION
### What does this PR do?
The last release of 1.1.0 failed due to a permissioning error when pushing to Dockerhub. Additionally we were unable to push a release because we lacked documentation and approval from the legal team on our NOTICES. 

This PR preps for a new release of 1.1.0

### What ticket does this PR close?
Connected to -

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation