### PR TITLE
Abort build after 3 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // we get the error "gcloud crashed : database is locked"
     disableConcurrentBuilds()
     buildDiscarder(logRotator(numToKeepStr: '30'))
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 3, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
For a reason unyet known our builds are taking ~2 hours 33 seconds. We seem to pass our tests every few rounds but the build terminates on the test integration test before we can succeed. This PR increases the threshold to 3 hours to allow for a green build