### PR TITLE
Add release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Push an edge release tag for every successful master build and automate the packaging of Secrets Provider Helm Chart as 
+  part of the pipeline ([cyberark/secrets-provider-for-k8s#234](https://github.com/cyberark/secrets-provider-for-k8s/pull/234))
+
 ### Changed
 - Update k8s authenticator client version to 
   [0.19.0](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0190---2020-10-08),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,13 +186,6 @@ follow the instructions in this section.
     1. [Version file](pkg/secrets/version.go)
     1. [Chart version](helm/secrets-provider/Chart.yaml)
     1. [Default deployed version](helm/secrets-provider/values.yaml)
-    
-1. Create a Helm package by running the following command from the repo root: `helm package helm/secrets-provider`.
-   The Helm package will be saved to the current folder and will resemble `secrets-provider-<version>.tgz`.
-1. Clone the repo [helm-charts](https://github.com/cyberark/helm-charts) and do the following:
-    1. Move the Helm package file created in the previous step to the *docs* folder in the `helm-charts` repo.
-    1. Go to the `helm-charts` repo root folder and execute the `reindex.sh` script file located there.
-    1. Create a PR with those changes.
 1. Review the git log and ensure the [changelog](CHANGELOG.md) contains all
    relevant recent changes with references to GitHub issues or PRs, if possible.
 1. Review the changes since the last tag, and if the dependencies have changed
@@ -210,6 +203,14 @@ follow the instructions in this section.
 1. Push the tag: `git push vx.y.z` (or `git push origin vx.y.z` if you are working
    from your local machine).
 
+### Push Helm package
+1. Every build packages the Secrets Provider Helm chart for us. The package can be found under the 'Artifacts' tab of the Jenkins build and will resemble `secrets-provider-<version>.tgz`. 
+Navigate to the 'Artifacts' tab of the _tagged version_ build and save this file. You will need it for the next step.
+1. Clone the repo [helm-charts](https://github.com/cyberark/helm-charts) and do the following:
+    1. Move the Helm package file created in the previous step to the *docs* folder in the `helm-charts` repo.
+    1. Go to the `helm-charts` repo root folder and execute the `reindex.sh` script file located there.
+    1. Create a PR with those changes.
+    
 ### Publish the git release
 1. In the GitHub UI, create a release from the new tag and copy the change log
 for the new version into the GitHub release description. The Jenkins pipeline 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,23 +79,38 @@ pipeline {
       }
     }
 
-    stage('Publish client Docker image') {
-      steps {
-        withCredentials(
-          [
-            usernamePassword(
-              credentialsId: 'conjur-jenkins-api',
-              usernameVariable: 'GIT_USER',
-              passwordVariable: 'GIT_PASSWORD'
-            )
-          ]
-        ) {
-            sh '''
-                git config --local credential.helper '! echo username=${GIT_USER}; echo password=${GIT_PASSWORD}; echo > /dev/null'
-                git fetch --tags
-                export GIT_DESCRIPTION=$(git describe --tags)
-                summon ./bin/publish
-            '''
+    stage('Release') {
+      parallel {
+        stage('Push Images') {
+          steps {
+            script {
+              BRANCH_NAME=env.BRANCH_NAME
+            }
+            withCredentials(
+              [
+                usernamePassword(
+                  credentialsId: 'conjur-jenkins-api',
+                  usernameVariable: 'GIT_USER',
+                  passwordVariable: 'GIT_PASSWORD'
+                )
+              ]
+            ) {
+                sh '''
+                    git config --local credential.helper '! echo username=${GIT_USER}; echo password=${GIT_PASSWORD}; echo > /dev/null'
+                    git fetch --tags
+                    export GIT_DESCRIPTION=$(git describe --tags)
+                    export BRANCH_NAME=${BRANCH_NAME}
+                    summon ./bin/publish
+                '''
+              }
+          }
+        }
+        stage('Package artifacts') {
+          steps {
+            sh 'ci/jenkins_build'
+
+            archiveArtifacts artifacts: "helm-artifacts/", fingerprint: false, allowEmptyArchive: true
+          }
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ When we release a version, we push the following images to Dockerhub:
 
 We also push the Major.Minor.Build image to our [Red Hat registry](https://catalog.redhat.com/software/containers/cyberark/secrets-provider-for-k8s/5ee814f0ac3db90370949cf0).
 
+# Builds
+
+We push the following tags to Dockerhub:
+
+*Edge* - on every successful master build an edge tag is pushed (_cyberark/secrets-provider-for-k8s:edge_).
+
+*Latest* - on every release the latest tag will be updated (_cyberark/secrets-provider-for-k8s:latest_). This tag means the Secrets Provider for Kubernetes meets the stability criteria detailed in the following section.
+ 
+*Semver* - on every release a Semver tag will be pushed (_cyberark/secrets-provider-for-k8s:1.1.0_). This tag means the Secrets Provider for Kubernetes meets the stability criteria detailed in the following section.
+
 ## Stable release definition
 
 The CyberArk Secrets Provider for Kubernetes is considered stable when it meets the core acceptance criteria:

--- a/bin/publish
+++ b/bin/publish
@@ -43,4 +43,8 @@ if [ "$GIT_DESCRIPTION" = "v${VERSION}" ]; then
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
+elif [ "$BRANCH_NAME" = "master" ]; then
+  echo "Successful Master build. Tagging and pushing $REGISTRY/$IMAGE_NAME:edge"
+  docker tag "$IMAGE_NAME:$FULL_VERSION_TAG" "$REGISTRY/$IMAGE_NAME:edge"
+  docker push "$REGISTRY/$IMAGE_NAME:edge"
 fi

--- a/ci/jenkins_build
+++ b/ci/jenkins_build
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+source bin/build_utils
+helm_version=3.3.0
+
+docker run --rm \
+  -v $PWD/helm/secrets-provider:/root/helm/secrets-provider \
+  -v $PWD/helm-artifacts/:/root/helm-artifacts \
+  --workdir /root/helm-artifacts \
+  alpine/helm:${helm_version} package ../helm/secrets-provider


### PR DESCRIPTION
This PR is part of a bigger effort in automating our release process
- Package helm chart on every build
- Add ability to push an edge tag on every master build
- Update tag and release process in docs

See generated helm package here: https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secrets-provider-for-k8s/detail/automate-release/31/artifacts

### What ticket does this PR close?
Connected to #233 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation