### PR TITLE
Collect container logs 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,9 @@ pipeline {
   }
 
   post {
+    always {
+         archiveArtifacts artifacts: "deploy/output/*.txt", fingerprint: false, allowEmptyArchive: true
+    }
     success {
       cleanupAndNotify(currentBuild.currentResult)
     }

--- a/bin/start
+++ b/bin/start
@@ -62,6 +62,7 @@ fi
 export RUN_IN_DOCKER
 export CONJUR_DEPLOYMENT
 export DEV
+export SUMMON_ENV
 
 # summon environment variable
 export CONJUR_MAJOR_VERSION=4

--- a/deploy/stop
+++ b/deploy/stop
@@ -3,6 +3,10 @@ set -euo pipefail
 
 . "$(dirname "${0}")/utils.sh"
 
+if has_namespace $APP_NAMESPACE_NAME; then
+  get_logs
+fi
+
 set_namespace default
 
 if [[ $PLATFORM == openshift ]]; then

--- a/deploy/test/test_in_docker.sh
+++ b/deploy/test/test_in_docker.sh
@@ -17,6 +17,7 @@ finish() {
 trap finish EXIT
 
 main() {
+  mkdir -p output #location where Secrets Provider/Conjur logs will be saved
   buildTestRunnerImage
   deployConjur
   deployTest


### PR DESCRIPTION
### What does this PR do?
We want to get our logs from our relevant pods when we have failure in the test. This repo use k8s-conjur-deploy and we want to get those logs as well. In case of failure we will get secrets provider logs and conjur/follower (depends on dap/oss).
I verified the following:
OSS with and without helm
DAP with and without helm
fix ticket #227 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation