### PR TITLE
Flaky tests - Fix SSL error from Helm integration tests

### DIFF
--- a/deploy/test/test_cases/TEST_ID_17_helm_job_deploys_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_17_helm_job_deploys_successfully.sh
@@ -8,7 +8,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Deploy app to test against

--- a/deploy/test/test_cases/TEST_ID_18_helm_multiple_provider_multiple_secrets.sh
+++ b/deploy/test/test_cases/TEST_ID_18_helm_multiple_provider_multiple_secrets.sh
@@ -13,7 +13,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 helm_chart_name="secrets-provider"
@@ -33,7 +33,7 @@ pushd ../../
   fill_helm_chart "another-"
   helm install -f "../helm/secrets-provider/ci/another-test-values-$UNIQUE_TEST_ID.yaml" \
     another-secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Wait for Job completion

--- a/deploy/test/test_cases/TEST_ID_19_helm_multiple_provider_same_secret.sh
+++ b/deploy/test/test_cases/TEST_ID_19_helm_multiple_provider_same_secret.sh
@@ -8,7 +8,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Check for Job completion
@@ -24,7 +24,7 @@ pushd ../../
   fill_helm_chart "another-"
   helm install -f "../helm/secrets-provider/ci/another-test-values-$UNIQUE_TEST_ID.yaml" \
     another-secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 helm_chart_name="another-secrets-provider"

--- a/deploy/test/test_cases/TEST_ID_20_helm_multiple_provider_same_serviceaccount.sh
+++ b/deploy/test/test_cases/TEST_ID_20_helm_multiple_provider_same_serviceaccount.sh
@@ -8,7 +8,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Check for Job completion
@@ -26,7 +26,7 @@ pushd ../../
   fill_helm_chart "another-"
   helm install -f "../helm/secrets-provider/ci/another-test-values-$UNIQUE_TEST_ID.yaml" \
     another-secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 helm_chart_name="another-secrets-provider"

--- a/deploy/test/test_cases/TEST_ID_21_helm_service_account_does_not_exist.sh
+++ b/deploy/test/test_cases/TEST_ID_21_helm_service_account_does_not_exist.sh
@@ -11,7 +11,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Job should fail and not be completed

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -16,7 +16,7 @@ pushd ../../
   fill_helm_chart_no_override_defaults
   helm install -f "../helm/secrets-provider/ci/take-default-test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 # Validate that known defaults were taken if not supplied

--- a/deploy/test/test_cases/TEST_ID_23_helm_service_account_exists.sh
+++ b/deploy/test/test_cases/TEST_ID_23_helm_service_account_exists.sh
@@ -17,7 +17,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 ## Validate that resources were not created

--- a/deploy/test/test_cases/TEST_ID_24_helm_validate_K8S_SECRETS_env_var_incorrect_value.sh
+++ b/deploy/test/test_cases/TEST_ID_24_helm_validate_K8S_SECRETS_env_var_incorrect_value.sh
@@ -13,7 +13,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 echo "Expecting Secrets Provider to fail with debug message 'CSPFK004D Failed to retrieve k8s secret. Reason: secrets K8S_SECRET-non-existent-secret not found'"

--- a/deploy/test/test_cases/TEST_ID_25_helm_default_retry_successful.sh
+++ b/deploy/test/test_cases/TEST_ID_25_helm_default_retry_successful.sh
@@ -31,7 +31,7 @@ pushd ../../
   helm install -f "../helm/secrets-provider/ci/take-default-test-values-$UNIQUE_TEST_ID.yaml" \
     -f "../helm/secrets-provider/ci/take-image-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-helm --no-headers | wc -l | tr -d ' ' | grep '^1$'"

--- a/deploy/test/test_cases/TEST_ID_26_helm_override_default_retry_successful.sh
+++ b/deploy/test/test_cases/TEST_ID_26_helm_override_default_retry_successful.sh
@@ -14,7 +14,7 @@ pushd ../../
   fill_helm_chart
   helm install -f "../helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
     secrets-provider ../helm/secrets-provider \
-    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur.pem"
+    --set-file environment.conjur.sslCertificate.value="test/test_cases/conjur-$UNIQUE_TEST_ID.pem"
 popd
 
 $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-helm --no-headers | wc -l | tr -d ' ' | grep '^1$'"

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -172,9 +172,9 @@ setup_helm_environment() {
 
   configure_conjur_url
 
-  ssl_location="conjur.pem"
+  ssl_location="conjur-$UNIQUE_TEST_ID.pem"
   if [ "${DEV}" = "true" ]; then
-    ssl_location="../conjur.pem"
+    ssl_location="../conjur-$UNIQUE_TEST_ID.pem"
   fi
 
   fetch_ssl_from_conjur
@@ -272,7 +272,7 @@ deploy_chart() {
     fill_helm_chart
     helm install -f "helm/secrets-provider/ci/test-values-$UNIQUE_TEST_ID.yaml" \
       secrets-provider ./helm/secrets-provider \
-      --set-file environment.conjur.sslCertificate.value="conjur.pem"
+      --set-file environment.conjur.sslCertificate.value="conjur-$UNIQUE_TEST_ID.pem"
   popd
 }
 


### PR DESCRIPTION
 We are experiencing flaky test failures. The two main failures are incomplete job status and SSL certificate failing to be passed in when deploying the Helm Chart. This fixes these flaky tests