### PR TITLE
Use `Resolves` in PR template to link issue to new PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 - _Are there relevant screenshots you can add to the PR description?_
 
 ### What ticket does this PR close?
-Connected to #[relevant GitHub issues, eg 76]
+Resolves #[relevant GitHub issues, eg 76]
 
 ### Checklists
 


### PR DESCRIPTION
In GitHub PR template, replace issue placeholder to make use of GitHub feature
that automatically links issue to PR.
For that, the issue should be prefixed by a 'resolved' keyword.

### What does this PR do?
Replace `Connected to` with `Resolves` when prefixing the related issue in PR template.
This enables GitHub auto-linking feature: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

### What ticket does this PR close?
Resolves #241

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation