### PR TITLE
Consume version 0.19.0 of conjur-authn-k8s-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update k8s authenticator client version to 
+  [0.19.0](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0190---2020-10-08),
+  which adds some fixes around cert injection failure (see also changes in 
+  [0.18.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0181---2020-09-13)).
 
 ## [1.1.0] - 2020-09-15
 ### Added

--- a/deploy/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
+++ b/deploy/test/test_cases/TEST_ID_11_conjur_authn_failure.sh
@@ -9,8 +9,8 @@ export CONJUR_AUTHN_LOGIN="host/some-policy/non-existing-namespace/*/*"
 
 deploy_init_env
 
-echo "Expecting secrets provider to fail with error CAKC015E Login failed"
+echo "Expecting secrets provider to fail with error CAKC015 Login failed"
 $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-env --no-headers | wc -l | tr -d ' ' | grep '^1$'"
 pod_name=$($cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-env --no-headers" | awk '{print $1}')
 
-$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CAKC015E"
+$cli_with_timeout "logs $pod_name -c cyberark-secrets-provider-for-k8s | grep CAKC015"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyberark/conjur-api-go v0.6.0
-	github.com/cyberark/conjur-authn-k8s-client v0.18.1
+	github.com/cyberark/conjur-authn-k8s-client v0.19.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,7 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cyberark/conjur-api-go v0.6.0 h1:QQYmFRhcCvmtZ9oSRoXCxWb7uRjppfu5lcEwo4HEjtg=
 github.com/cyberark/conjur-api-go v0.6.0/go.mod h1:uM96pLpckwYYAWRSbrsw+TT0y3kg49QCEGpdpa9dJ34=
-github.com/cyberark/conjur-authn-k8s-client v0.18.1 h1:ka397W4Q6AyBxzszvFtuuTtBN6CQ2S5RCMjGsmhonww=
-github.com/cyberark/conjur-authn-k8s-client v0.18.1/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
+github.com/cyberark/conjur-authn-k8s-client v0.19.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This version introduces some changes that we can benefit from, especially these:
- Errors in the certificate injection process on login are now printed to the client logs.
  [cyberark/conjur-authn-k8s-client#/170](https://github.com/cyberark/conjur-authn-k8s-client/issues/170)
