### PR TITLE
Add missing PR link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Push an edge release tag for every successful master build and automate the packaging of Secrets Provider Helm Chart as 
-  part of the pipeline ([cyberark/secrets-provider-for-k8s#234](https://github.com/cyberark/secrets-provider-for-k8s/pull/234))
+  part of the pipeline. [cyberark/secrets-provider-for-k8s#234](https://github.com/cyberark/secrets-provider-for-k8s/pull/234)
 
 ### Changed
 - Use logger from k8s authenticator client; its timestamp format contains milliseconds precision.
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update k8s authenticator client version to 
   [0.19.0](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0190---2020-10-08),
   which adds some fixes around cert injection failure (see also changes in 
-  [0.18.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0181---2020-09-13)).
+  [0.18.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0181---2020-09-13)). [cyberark/secrets-provider-for-k8s#247](https://github.com/cyberark/secrets-provider-for-k8s/pull/247)
 
 ## [1.1.0] - 2020-09-15
 ### Added


### PR DESCRIPTION
This PR adds a missing Changelog link, and updates the link formatting for another entry to adhere to our [Changelog Guidelines](https://github.com/cyberark/community/blob/master/Conjur/CONTRIBUTING.md#changelog-guidelines).