### PR TITLE
Correctly set the tag in the project's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   which adds some fixes around cert injection failure (see also changes in 
   [0.18.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0181---2020-09-13)). [cyberark/secrets-provider-for-k8s#247](https://github.com/cyberark/secrets-provider-for-k8s/pull/247)
 
+### Fixed
+- The version that is printed at the product's startup now includes the git commit
+  hash instead of a hard-coded 'dev' string.
+  [cyberark/secrets-provider-for-k8s#256](https://github.com/cyberark/secrets-provider-for-k8s/issues/256)
+
 ## [1.1.0] - 2020-09-15
 ### Added
 - Helm chart to deploy the Secrets Provider Job using Helm ([cyberark/secrets-provider-for-k8s#165](https://github.com/cyberark/secrets-provider-for-k8s/pulls/165))

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,15 @@ FROM secrets-provider-builder-base as secrets-provider-builder
 
 COPY . .
 
-RUN go build -a -installsuffix cgo -o secrets-provider ./cmd/secrets-provider
+# this value is set in ./bin/build
+ARG TAG
+
+RUN go build \
+    -a \
+    -installsuffix cgo \
+    -ldflags="-X github.com/cyberark/secrets-provider-for-k8s/pkg/secrets.Tag=$TAG" \
+    -o secrets-provider \
+    ./cmd/secrets-provider
 
 # =================== DEBUG BUILD LAYER ===================
 # this layer is used to build the debug binaries

--- a/bin/build
+++ b/bin/build
@@ -27,6 +27,7 @@ if [ $DEBUG = true ]; then
   echo "Building secrets-provider-debug Docker image"
 
   docker build \
+    --build-arg TAG="debug" \
     --tag "secrets-provider-for-k8s-debug:latest" \
     --target "secrets-provider-debug" \
     .
@@ -34,6 +35,7 @@ else
   echo "Building secrets-provider-for-k8s:$FULL_VERSION_TAG Docker image"
 
   docker build \
+    --build-arg TAG=$(git_tag) \
     --tag "secrets-provider-for-k8s:dev" \
     --tag "secrets-provider-for-k8s:${FULL_VERSION_TAG}" \
     --tag "secrets-provider-for-k8s:latest" \
@@ -42,8 +44,10 @@ else
 
   echo "Building secrets-provider-for-k8s-redhat:$FULL_VERSION_TAG Docker image"
 
-  docker build --tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" \
+  docker build \
+     --build-arg TAG=$(git_tag) \
      --build-arg VERSION="$FULL_VERSION_TAG" \
+     --tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" \
      --target "secrets-provider-for-k8s-redhat" \
      .
 fi


### PR DESCRIPTION
### What does this PR do?
When the secrets-provider starts it writes its version to the log.
Currently, it always writes
```
CSPFK008I CyberArk Secrets Provider for Kubernetes v1.1.0-dev starting up
```

Note that the `dev` is hard-coded.

After this commit, we correctly write the git tag of the version:
```
CSPFK008I CyberArk Secrets Provider for Kubernetes v1.1.0-f463bf8 starting up
```

### What ticket does this PR close?
Resolves #256

### Checklists

#### Change log
- [x] The CHANGELOG has been updated