### PR TITLE
Skip build and test for markdown files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,117 +22,126 @@ pipeline {
       }
     }
 
-    stage('Build client Docker image') {
-      steps {
-        sh './bin/build'
+    stage('Build and test Secrets Provider') {
+      when {
+        expression {
+         sh(returnStatus: true, script: 'git diff origin/master --name-only | grep -v "^.*\\.md$" > /dev/null') == 0
+        }
       }
-    }
-
-    stage('Scan Docker Image') {
-      parallel {
-        stage("Scan Docker Image for fixable issues") {
+      stages {
+        stage('Build client Docker image') {
           steps {
-            // Adding the false parameter to scanAndReport causes trivy to
-            // ignore vulnerabilities for which no fix is available. We'll
-            // only fail the build if we can actually fix the vulnerability
-            // right now.
-            scanAndReport('secrets-provider-for-k8s:latest', "HIGH", false)
+            sh './bin/build'
           }
         }
-        stage("Scan Docker image for total issues") {
-          steps {
-            // By default, trivy includes vulnerabilities with no fix. We
-            // want to know about that ASAP, but they shouldn't cause a
-            // build failure until we can do something about it. This call
-            // to scanAndReport should always be left as "NONE"
-            scanAndReport("secrets-provider-for-k8s:latest", "NONE", true)
+
+        stage('Scan Docker Image') {
+          parallel {
+            stage("Scan Docker Image for fixable issues") {
+              steps {
+                // Adding the false parameter to scanAndReport causes trivy to
+                // ignore vulnerabilities for which no fix is available. We'll
+                // only fail the build if we can actually fix the vulnerability
+                // right now.
+                scanAndReport('secrets-provider-for-k8s:latest', "HIGH", false)
+              }
+            }
+            stage("Scan Docker image for total issues") {
+              steps {
+                // By default, trivy includes vulnerabilities with no fix. We
+                // want to know about that ASAP, but they shouldn't cause a
+                // build failure until we can do something about it. This call
+                // to scanAndReport should always be left as "NONE"
+                scanAndReport("secrets-provider-for-k8s:latest", "NONE", true)
+              }
+            }
           }
         }
-      }
-    }
 
-    stage('Run Unit Tests') {
-      steps {
-        sh './bin/test_unit'
+        stage('Run Unit Tests') {
+          steps {
+            sh './bin/test_unit'
 
-        junit 'junit.xml'
-        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '30, 0, 0', failUnhealthy: true, failUnstable: false, maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-        ccCoverage("gocov", "--prefix github.com/cyberark/secrets-provider-for-k8s")
-      }
-    }
-
-    // We want to avoid running in parallel.
-    // When we have 2 build running on the same environment (gke env only) in parallel,
-    // we get the error "gcloud crashed : database is locked"
-    stage ("Run Integration Tests on oss") {
-      steps {
-        script {
-          def tasks = [:]
-            tasks["Kubernetes GKE, oss"] = {
-              sh "./bin/start --docker --oss --gke"
-            }
-            // tasks["Openshift v3.11, oss"] = {
-            //  sh "./bin/start --docker --oss --oc311"
-            // }
-            // skip oc310 tests until the environment will be ready to use
-            // tasks["Openshift v3.10, oss"] = {
-            //   sh "./bin/start --docker --oss --oc310"
-            // }
-          parallel tasks
+            junit 'junit.xml'
+            cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '30, 0, 0', failUnhealthy: true, failUnstable: false, maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+            ccCoverage("gocov", "--prefix github.com/cyberark/secrets-provider-for-k8s")
+          }
         }
-      }
-    }
 
-    stage ("Run Integration Tests on DAP") {
-      steps {
-        script {
-          def tasks = [:]
-            tasks["Kubernetes GKE, DAP"] = {
-              sh "./bin/start --docker --dap --gke"
-            }
-            tasks["Openshift v3.11, DAP"] = {
-              sh "./bin/start --docker --dap --oc311"
-            }
-            // skip oc310 tests until the environment will be ready to use
-            // tasks["Openshift v3.10, DAP"] = {
-            //  sh "./bin/start --docker --dap --oc310"
-            // }
-          parallel tasks
-        }
-      }
-    }
-
-    stage('Release') {
-      parallel {
-        stage('Push Images') {
+        // We want to avoid running in parallel.
+        // When we have 2 build running on the same environment (gke env only) in parallel,
+        // we get the error "gcloud crashed : database is locked"
+        stage ("Run Integration Tests on oss") {
           steps {
             script {
-              BRANCH_NAME=env.BRANCH_NAME
+              def tasks = [:]
+                tasks["Kubernetes GKE, oss"] = {
+                  sh "./bin/start --docker --oss --gke"
+                }
+                // tasks["Openshift v3.11, oss"] = {
+                //  sh "./bin/start --docker --oss --oc311"
+                // }
+                // skip oc310 tests until the environment will be ready to use
+                // tasks["Openshift v3.10, oss"] = {
+                //   sh "./bin/start --docker --oss --oc310"
+                // }
+              parallel tasks
             }
-            withCredentials(
-              [
-                usernamePassword(
-                  credentialsId: 'conjur-jenkins-api',
-                  usernameVariable: 'GIT_USER',
-                  passwordVariable: 'GIT_PASSWORD'
-                )
-              ]
-            ) {
-                sh '''
-                    git config --local credential.helper '! echo username=${GIT_USER}; echo password=${GIT_PASSWORD}; echo > /dev/null'
-                    git fetch --tags
-                    export GIT_DESCRIPTION=$(git describe --tags)
-                    export BRANCH_NAME=${BRANCH_NAME}
-                    summon ./bin/publish
-                '''
-              }
           }
         }
-        stage('Package artifacts') {
-          steps {
-            sh 'ci/jenkins_build'
 
-            archiveArtifacts artifacts: "helm-artifacts/", fingerprint: false, allowEmptyArchive: true
+        stage ("Run Integration Tests on DAP") {
+          steps {
+            script {
+              def tasks = [:]
+                tasks["Kubernetes GKE, DAP"] = {
+                  sh "./bin/start --docker --dap --gke"
+                }
+                tasks["Openshift v3.11, DAP"] = {
+                  sh "./bin/start --docker --dap --oc311"
+                }
+                // skip oc310 tests until the environment will be ready to use
+                // tasks["Openshift v3.10, DAP"] = {
+                //  sh "./bin/start --docker --dap --oc310"
+                // }
+              parallel tasks
+            }
+          }
+        }
+
+        stage('Release') {
+          parallel {
+            stage('Push Images') {
+              steps {
+                script {
+                  BRANCH_NAME=env.BRANCH_NAME
+                }
+                withCredentials(
+                  [
+                    usernamePassword(
+                      credentialsId: 'conjur-jenkins-api',
+                      usernameVariable: 'GIT_USER',
+                      passwordVariable: 'GIT_PASSWORD'
+                    )
+                  ]
+                ) {
+                    sh '''
+                        git config --local credential.helper '! echo username=${GIT_USER}; echo password=${GIT_PASSWORD}; echo > /dev/null'
+                        git fetch --tags
+                        export GIT_DESCRIPTION=$(git describe --tags)
+                        export BRANCH_NAME=${BRANCH_NAME}
+                        summon ./bin/publish
+                    '''
+                  }
+              }
+            }
+            stage('Package artifacts') {
+              steps {
+                sh 'ci/jenkins_build'
+
+                archiveArtifacts artifacts: "helm-artifacts/", fingerprint: false, allowEmptyArchive: true
+              }
+            }
           }
         }
       }
@@ -141,19 +150,19 @@ pipeline {
 
   post {
     always {
-         archiveArtifacts artifacts: "deploy/output/*.txt", fingerprint: false, allowEmptyArchive: true
+      archiveArtifacts artifacts: "deploy/output/*.txt", fingerprint: false, allowEmptyArchive: true
     }
     success {
       cleanupAndNotify(currentBuild.currentResult)
     }
     unsuccessful {
-        script {
-            if (env.BRANCH_NAME == 'master') {
-              cleanupAndNotify(currentBuild.currentResult, "#development", "@secrets-provider-for-k8s-owners")
-            } else {
-              cleanupAndNotify(currentBuild.currentResult, "#development")
-            }
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          cleanupAndNotify(currentBuild.currentResult, "#development", "@secrets-provider-for-k8s-owners")
+        } else {
+          cleanupAndNotify(currentBuild.currentResult, "#development")
         }
+      }
     }
   }
 }


### PR DESCRIPTION
This will skip building the appliance and running all of the tests if the
branch only contains changes to markdown files.
It will still run the changelog parser so operations on markdown files still
happen, but blocks off the build and test portion of the build.

### What does this PR do?
Skip jenkins pipeline for PRs that include only `.md` files changes.
This allows easier working on docs in the repo, that does not have impact on code.

Similar changes in `conjur`: https://github.com/cyberark/conjur/pull/1939

### What ticket does this PR close?
Resolves #264 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation