### PR TITLE
Always run pipeline on tags and nightly tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,34 @@ pipeline {
 
     stage('Build and test Secrets Provider') {
       when {
-        expression {
-         sh(returnStatus: true, script: 'git diff origin/master --name-only | grep -v "^.*\\.md$" > /dev/null') == 0
+        // Run tests only when EITHER of the following is true:
+        // 1. A non-markdown file has changed.
+        // 2. It's the nightly build.
+        // 3. It's triggered by conjur's build
+        // 4. It's a tag-triggered build.
+        anyOf {
+          // Note: You cannot use "when"'s changeset condition here because it's
+          // not powerful enough to express "_only_ md files have changed".
+          // Dropping down to a git script was the easiest alternative.
+          expression {
+            0 == sh(
+              returnStatus: true,
+              // A non-markdown file has changed.
+              script: '''
+                git diff  origin/master --name-only |
+                grep -v "^.*\\.md$" > /dev/null
+              '''
+            )
+          }
+
+          // Always run the full pipeline on nightly builds
+          expression { params.NIGHTLY }
+
+          // Always run the full pipeline when triggered by conjur build
+          expression { getTrigger() == "upstreambuild" }
+
+          // Always run the full pipeline on tags of the form v*
+          tag "v*"
         }
       }
       stages {


### PR DESCRIPTION
This PR merges the same changes introduced for `conjur` at these PRs:
https://github.com/cyberark/conjur/pull/1946
https://github.com/cyberark/conjur/pull/1951

Recently, we introduced a change to skip running the CI tests when the
only changed files were markdown files, so that design doc and other
non-code PRs wouldn't block on the CI.

However, this had the unintended side-effect of skipping our nightly
builds, because the criteria for "only markdown files":

git diff origin/master --name-only | grep -v "^.*\\.md$" > /dev/null'

will also _always_ be true when a nightly build is auto-triggered.

This commit ensures that the nightly builds and tag release builds will always be run.

### What ticket does this PR close?
Resolves #264

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation