### PR TITLE
Update Jenkinsfile to run pipeline on tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,30 @@ pipeline {
 
     stage('Build and test Secrets Provider') {
       when {
-        expression {
-         sh(returnStatus: true, script: 'git diff origin/master --name-only | grep -v "^.*\\.md$" > /dev/null') == 0
+        // Run tests only when ANY of the following is true:
+        // 1. A non-markdown file has changed.
+        // 2. It's the nightly build.
+        // 3. It's a tag-triggered build.
+        anyOf {
+          // Note: You cannot use "when"'s changeset condition here because it's
+          // not powerful enough to express "_only_ md files have changed".
+          // Dropping down to a git script was the easiest alternative.
+          expression {
+            0 == sh(
+              returnStatus: true,
+              // A non-markdown file has changed.
+              script: '''
+                git diff  origin/master --name-only |
+                grep -v "^.*\\.md$" > /dev/null
+              '''
+            )
+          }
+
+          // Always run the full pipeline on nightly builds
+          expression { params.NIGHTLY }
+
+          // Always run the full pipeline on tags of the form v*
+          tag "v*"
         }
       }
       stages {


### PR DESCRIPTION
### What does this PR do?
The Jenkinsfile was recently updated to skip a full run when the build includes
only markdown changes. This also means, however, that nightly and tag builds
are skipped.

This commit updates the Jenkinsfile so that the build will also run on tags
and nightly builds.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation