### PR TITLE
Always run pipeline on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,9 +26,7 @@ pipeline {
       when {
         // Run tests only when EITHER of the following is true:
         // 1. A non-markdown file has changed.
-        // 2. It's the nightly build.
-        // 3. It's triggered by conjur's build
-        // 4. It's a tag-triggered build.
+        // 2. It's the master branch.
         anyOf {
           // Note: You cannot use "when"'s changeset condition here because it's
           // not powerful enough to express "_only_ md files have changed".
@@ -44,14 +42,8 @@ pipeline {
             )
           }
 
-          // Always run the full pipeline on nightly builds
-          expression { params.NIGHTLY }
-
-          // Always run the full pipeline when triggered by conjur build
-          expression { getTrigger() == "upstreambuild" }
-
-          // Always run the full pipeline on tags of the form v*
-          tag "v*"
+          // Always run the full pipeline on master branch
+          branch 'master'
         }
       }
       stages {


### PR DESCRIPTION
Recently, we introduced a change to skip running the CI tests when the
only changed files were markdown files, so that design doc and other
non-code PRs wouldn't block on the CI.

However, this had the unintended side-effect of skipping our builds
on the master branch as well.

This commit ensures that the master branch builds will always be run.

### What ticket does this PR close?
Resolves #264

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation