### PR TITLE
add apt-get update before install apt-transport-https

### DIFF
--- a/deploy/test/Dockerfile
+++ b/deploy/test/Dockerfile
@@ -27,8 +27,9 @@ RUN mkdir -p ocbin && \
 
 # Install Helm
 RUN curl https://baltocdn.com/helm/signing.asc | apt-key add - && \
+    apt-get update -y && \
     apt-get install apt-transport-https --yes && \
-    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list && \
+    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list && \
     apt-get update && \
     apt-get install helm=3.2.*
 


### PR DESCRIPTION
### What does this PR do?
add apt-get update before install apt-transport-https and remove sudo since the container doesnt support it.  

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation