### PR TITLE
Adds test flows for OCP 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for OpenShift 4.5.
+  [cyberark/secrets-provider-for-k8s#265](https://github.com/cyberark/secrets-provider-for-k8s/issues/265)
+
+### Deprecated
+- Support for OpenShift 3.9 and 3.10 is officially removed as of this release.
+  [cyberark/secrets-provider-for-k8s#265](https://github.com/cyberark/secrets-provider-for-k8s/issues/265)
+
 ## [1.1.1] - 2020-11-24
 ### Added
 - An `edge` tag is published for every successful master build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ To follow [Go testing conventions](https://golang.org/pkg/cmd/go/internal/test/)
 Our integration tests can be run against either a GKE / Openshift remote cluster. To do so, run `./bin/start` and add the proper flags. 
 
 To deploy OSS / DAP, add the `--oss` / `--dap` flags to the above command. By default, the integration tests run DAP, so no flag is required.
-To deploy on GKE / Openshift, add `--gke` / `--oc311` / `oc310`. By default, the integration tests run on a GKE cluster, so no flag is required.
+To deploy on GKE / Openshift, add `--gke` / `--oc311` / `--oc45`. By default, the integration tests run on a GKE cluster, so no flag is required.
 
 For example:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,13 +96,6 @@ pipeline {
                 tasks["Kubernetes GKE, oss"] = {
                   sh "./bin/start --docker --oss --gke"
                 }
-                // tasks["Openshift v3.11, oss"] = {
-                //  sh "./bin/start --docker --oss --oc311"
-                // }
-                // skip oc310 tests until the environment will be ready to use
-                // tasks["Openshift v3.10, oss"] = {
-                //   sh "./bin/start --docker --oss --oc310"
-                // }
               parallel tasks
             }
           }
@@ -118,10 +111,9 @@ pipeline {
                 tasks["Openshift v3.11, DAP"] = {
                   sh "./bin/start --docker --dap --oc311"
                 }
-                // skip oc310 tests until the environment will be ready to use
-                // tasks["Openshift v3.10, DAP"] = {
-                //  sh "./bin/start --docker --dap --oc310"
-                // }
+                tasks["Openshift v4.5, DAP"] = {
+                  sh "./bin/start --docker --dap --oc45"
+                }
               parallel tasks
             }
           }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To deploy the CyberArk Secrets Provider for Kubernetes as an application contain
 
 - K8s 1.11+
 
-- Openshift 3.9, 3.10, and 3.11 _*(DAP only)*_
+- Openshift 3.11 and 4.5 _*(DAP only)*_
 
 ## Using secrets-provider-for-k8s with Conjur OSS 
 

--- a/bin/start
+++ b/bin/start
@@ -22,7 +22,7 @@ Usage: ./bin/start [options]
 
     --oc311       Run the integration tests on Openshift v3.11. By default the tests are run on GKE.
 
-    --oc310       Run the integration tests on Openshift v3.10. By default the tests are run on GKE.
+    --oc45       Run the integration tests on Openshift v4.5. By default the tests are run on GKE.
 
     -h, --help    Shows this help message.
 EOF
@@ -49,7 +49,7 @@ while true ; do
     --dap ) CONJUR_DEPLOYMENT=dap ; shift ;;
     --gke ) SUMMON_ENV=gke ; shift ;;
     --oc311 ) SUMMON_ENV=oc311 ; shift ;;
-    --oc310 ) SUMMON_ENV=oc310 ; shift ;;
+    --oc45 ) SUMMON_ENV=oc45 ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac

--- a/deploy/2_create_app_namespace.sh
+++ b/deploy/2_create_app_namespace.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 announce "Creating Application namespace."
 
 if [[ $PLATFORM == openshift && "${DEV}" = "false" ]]; then
-  $cli_with_timeout "login -u $OPENSHIFT_USERNAME"
+  $cli_with_timeout "login -u $OPENSHIFT_USERNAME -p $OPENSHIFT_PASSWORD"
 fi
 
 if has_namespace "$APP_NAMESPACE_NAME"; then
@@ -38,5 +38,5 @@ if [[ $PLATFORM == openshift ]]; then
   $cli_with_timeout "adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n default"
   $cli_with_timeout "adm policy add-role-to-user admin $OPENSHIFT_USERNAME -n $APP_NAMESPACE_NAME"
   echo "Logging in as Conjur Openshift admin. Provide password as needed."
-  $cli_with_timeout "login -u $OPENSHIFT_USERNAME"
+  $cli_with_timeout "login -u $OPENSHIFT_USERNAME -p $OPENSHIFT_PASSWORD"
 fi

--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -57,7 +57,7 @@ spec:
                 name: test-k8s-secret
                 key: non-conjur-key
       initContainers:
-      - image: '${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
         imagePullPolicy: Always
         name: cyberark-secrets-provider-for-k8s
         env:

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -56,7 +56,7 @@ spec:
                 name: test-k8s-secret
                 key: non-conjur-key
       initContainers:
-      - image: '${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
         imagePullPolicy: Always
         name: cyberark-secrets-provider-for-k8s
         env:

--- a/deploy/platform_login.sh
+++ b/deploy/platform_login.sh
@@ -16,11 +16,9 @@ main() {
       -u oauth2accesstoken \
       -p "$(gcloud auth print-access-token)"
   elif [[ "$PLATFORM" = "openshift" ]]; then
-    # sensible default for OPENSHIFT_URL port
-    if [[ -n "${OPENSHIFT_URL}" ]] && [[ "${OPENSHIFT_URL}" != *: ]]; then
-     OPENSHIFT_URL="${OPENSHIFT_URL}:8443"
+    if [[ -n "${OPENSHIFT_URL}" ]] && [[ ! "${OPENSHIFT_URL}" =~ :[[:digit:]] ]]; then
+      OPENSHIFT_URL="${OPENSHIFT_URL}:8443"
     fi
-
     oc login "$OPENSHIFT_URL" \
       --username=$OPENSHIFT_USERNAME \
       --password=$OPENSHIFT_PASSWORD \

--- a/deploy/platform_login.sh
+++ b/deploy/platform_login.sh
@@ -16,6 +16,8 @@ main() {
       -u oauth2accesstoken \
       -p "$(gcloud auth print-access-token)"
   elif [[ "$PLATFORM" = "openshift" ]]; then
+    # Some of the URLs do not have the port loaded in conjurops so we need to
+    # add it manually
     if [[ -n "${OPENSHIFT_URL}" ]] && [[ ! "${OPENSHIFT_URL}" =~ :[[:digit:]] ]]; then
       OPENSHIFT_URL="${OPENSHIFT_URL}:8443"
     fi

--- a/deploy/stop
+++ b/deploy/stop
@@ -10,7 +10,7 @@ fi
 set_namespace default
 
 if [[ $PLATFORM == openshift ]]; then
-  $cli_with_timeout login -u $OPENSHIFT_USERNAME
+  $cli_with_timeout login -u $OPENSHIFT_USERNAME -p $OPENSHIFT_PASSWORD
 fi
 
 if has_namespace $APP_NAMESPACE_NAME; then

--- a/deploy/summon/secrets.yml
+++ b/deploy/summon/secrets.yml
@@ -38,14 +38,20 @@ oc311:
   TEST_PLATFORM: openshift311
   DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
+  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
 
-oc310:
-  OPENSHIFT_VERSION: '3.10'
-  OPENSHIFT_URL: !var ci/openshift/3.10/hostname
-  OPENSHIFT_USERNAME: !var ci/openshift/3.10/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/3.10/password
+oc45:
+  OPENSHIFT_VERSION: '4.5'
+  OPENSHIFT_URL: !var ci/openshift/current/api-url
+  OPENSHIFT_USERNAME: !var ci/openshift/current/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/current/password
+  OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/current/username
+  OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/current/username
 
   PLATFORM: openshift
-  TEST_PLATFORM: openshift310
-  DOCKER_REGISTRY_URL: !var ci/openshift/3.10/registry-url
-  DOCKER_REGISTRY_PATH: !var ci/openshift/3.10/registry-url
+  TEST_PLATFORM: openshift45
+  DOCKER_REGISTRY_URL: !var ci/openshift/current/registry-url
+  DOCKER_REGISTRY_PATH: !var ci/openshift/current/registry-url
+  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/current/internal-registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url

--- a/deploy/test/test_cases/test_case_setup.sh
+++ b/deploy/test/test_cases/test_case_setup.sh
@@ -7,7 +7,7 @@ if [ "${DEV}" = "false" ]; then
    $cli_with_timeout delete --ignore-not-found secret dockerpullsecret
 
    $cli_with_timeout create secret docker-registry dockerpullsecret \
-    --docker-server=${DOCKER_REGISTRY_URL} \
+    --docker-server="${PULL_DOCKER_REGISTRY_URL}" \
     --docker-username=_ \
     --docker-password=_ \
     --docker-email=_
@@ -15,7 +15,7 @@ if [ "${DEV}" = "false" ]; then
     $cli_with_timeout delete --ignore-not-found secrets dockerpullsecret
 
     $cli_with_timeout create secret docker-registry dockerpullsecret \
-      --docker-server=${DOCKER_REGISTRY_PATH} \
+      --docker-server="${PULL_DOCKER_REGISTRY_PATH}" \
       --docker-username=_ \
       --docker-password=$($cli_with_timeout whoami -t) \
       --docker-email=_

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -109,6 +109,8 @@ runDockerCommand() {
     -e OPENSHIFT_PASSWORD \
     -e DOCKER_REGISTRY_PATH \
     -e DOCKER_REGISTRY_URL \
+    -e PULL_DOCKER_REGISTRY_PATH \
+    -e PULL_DOCKER_REGISTRY_URL \
     -e GCLOUD_CLUSTER_NAME \
     -e GCLOUD_ZONE \
     -e GCLOUD_PROJECT_NAME \
@@ -203,7 +205,7 @@ set_image_path() {
   image_path="$APP_NAMESPACE_NAME"
   if [[ "${PLATFORM}" = "openshift" && "${DEV}" = "false" ]]; then
     # Image path needs to point to internal registry path to access image
-    image_path="docker-registry.default.svc:5000/${APP_NAMESPACE_NAME}"
+    image_path="${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}"
   elif [[ "${PLATFORM}" = "kubernetes" && "${DEV}" = "false" ]]; then
     image_path="${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}"
   fi


### PR DESCRIPTION
### What does this PR do?
- Removes test flows for OCP versions under 3.11
- Updates documented supported versions of OCP in README and adds deprecation
  notice in CHANGELOG

Note: this code just adds the test flows, but I will be surprised if it passes as-is. It's likely that some other small changes will need to be made to get this working.

### What ticket does this PR close?
Resolves #265 
Resolves #275 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation