### PR TITLE
Add ability to run a single test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,15 +9,23 @@ Thanks for your interest in the CyberArk Secrets Provider for Kubernetes. We wel
     + [Go](#go)
   * [Documentation](#documentation)
     + [Get up and running](#get-up-and-running)
+    + [Deploy a Local Dev Environment (K8s)](#deploy-a-local-dev-environment--k8s-)
+      - [Prerequisites](#prerequisites-1)
+      - [Deploy a local development environment](#deploy-a-local-development-environment)
+      - [Clean-up](#clean-up)
+      - [Limitations](#limitations)
   * [Contributing](#contributing)
     + [Contributing workflow](#contributing-workflow)
     + [Testing](#testing)
       - [Unit testing](#unit-testing)
       - [Integration testing](#integration-testing)
   * [Releases](#releases)
+    + [Pre-requisites](#pre-requisites)
     + [Update the version, changelog, and notices](#update-the-version--changelog--and-notices)
     + [Add a git tag](#add-a-git-tag)
+    + [Push Helm package](#push-helm-package)
     + [Publish the git release](#publish-the-git-release)
+    + [Publish the Red Hat image](#publish-the-red-hat-image)
 
 ## Prerequisites
 
@@ -70,7 +78,7 @@ You can now deploy a local development environment for Kubernetes using [Docker 
   
 1. If you intend to deploy the Secrets Provider via Helm, you will need to install the Helm CLI. See [here](https://helm.sh/docs/intro/install/) for instructions on how to do so.
 
-#### Deploy
+#### Deploy a local development environment
 
 To deploy a local development environment, perform the following:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,10 @@ For example:
 - Deploy OSS on GKE, run  `./bin/start --oss --gke`
 - Deploy DAP on Openshift, run  `./bin/start --dap --oc311`
 
+It is also possible to run a single test instead of the full suite. This can be done by running `./bin/start` with the
+flag `--test-prefix=<prefix>`. For example, running with the flag `--test-prefix=TEST_ID_18` will run only the test
+`TEST_ID_18_helm_multiple_provider_multiple_secrets.sh`, or run with the flag `--test-prefix=*1[789]` to run tests 17,18,19.
+
 When contributing new integration tests, perform the following:
 
 1. Navigate to the `test/test_case` folder

--- a/bin/start
+++ b/bin/start
@@ -43,6 +43,7 @@ while true ; do
   case "$1" in
     --docker ) RUN_IN_DOCKER=true ; shift ;;
     --dev ) DEV=true ; shift ;;
+    --test-prefix=* ) TEST_NAME_PREFIX="${1#*=}" ; export TEST_NAME_PREFIX; shift ;;
     --reload ) RELOAD_ENV=true ; shift ;;
     --oss ) CONJUR_DEPLOYMENT=oss ; shift ;;
     --dap ) CONJUR_DEPLOYMENT=dap ; shift ;;

--- a/deploy/1_check_dependencies.sh
+++ b/deploy/1_check_dependencies.sh
@@ -14,15 +14,17 @@ check_env_var "CONJUR_NAMESPACE_NAME"
 
 check_env_var "APP_NAMESPACE_NAME"
 
-if [[ "$PLATFORM" = "openshift" && "${DEV}" = "false" ]]; then
+if [[ "${DEV}" = "false" ]]; then
   check_env_var "DOCKER_REGISTRY_PATH"
-  check_env_var "OPENSHIFT_USERNAME"
-  check_env_var "OPENSHIFT_PASSWORD"
-elif [[ "$PLATFORM" = "kubernetes" && "${DEV}" = "false" ]]; then
-  check_env_var "DOCKER_REGISTRY_PATH"
-  check_env_var "GCLOUD_SERVICE_KEY"
-  check_env_var "GCLOUD_CLUSTER_NAME"
-  check_env_var "GCLOUD_ZONE"
-  check_env_var "GCLOUD_PROJECT_NAME"
   check_env_var "DOCKER_REGISTRY_URL"
+
+  if [[ "$PLATFORM" = "openshift" ]]; then
+    check_env_var "OPENSHIFT_USERNAME"
+    check_env_var "OPENSHIFT_PASSWORD"
+  elif [[ "$PLATFORM" = "kubernetes" ]]; then
+    check_env_var "GCLOUD_SERVICE_KEY"
+    check_env_var "GCLOUD_CLUSTER_NAME"
+    check_env_var "GCLOUD_ZONE"
+    check_env_var "GCLOUD_PROJECT_NAME"
+  fi
 fi

--- a/deploy/test/test_cases/run_tests.sh
+++ b/deploy/test/test_cases/run_tests.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# By default lookup for folders with specifics prefix of type 'test_'. Can be modified by passing argument.
-TEST_NAME_PREFIX=${1:-TEST_ID_}
+# By default lookup for folders with specifics prefix of type 'test_'.
+# Can be modified by using the `--test-prefix` flag for running `./bin/start`.
+TEST_NAME_PREFIX=${TEST_NAME_PREFIX:-TEST_ID_}
 
 # Keep environment variables for debugging
 printenv > printenv.debug

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -1,6 +1,14 @@
 export KEY_VALUE_NOT_EXIST=" "
 mkdir -p output
 
+if [ $PLATFORM = "kubernetes" ]; then
+    cli_with_timeout="wait_for_it 300 kubectl"
+    cli_without_timeout=kubectl
+elif [ $PLATFORM = "openshift" ]; then
+    cli_with_timeout="wait_for_it 300 oc"
+    cli_without_timeout=oc
+fi
+
 wait_for_it() {
   local timeout=$1
   local spacer=5
@@ -25,14 +33,6 @@ wait_for_it() {
     echo 'Success!'
   fi
 }
-
-if [ $PLATFORM = "kubernetes" ]; then
-    cli_with_timeout="wait_for_it 300 kubectl"
-    cli_without_timeout=kubectl
-elif [ $PLATFORM = "openshift" ]; then
-    cli_with_timeout="wait_for_it 300 oc"
-    cli_without_timeout=oc
-fi
 
 check_env_var() {
   if [[ -z "${!1+x}" ]]; then

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -21,7 +21,7 @@ wait_for_it() {
     while ! eval $* > /dev/null; do
       sleep $spacer
     done
-  echo 'Success!'
+    echo 'Success!'
   fi
 }
 
@@ -109,6 +109,7 @@ runDockerCommand() {
     -e MINIKUBE \
     -e MINISHIFT \
     -e DEV \
+    -e TEST_NAME_PREFIX \
     -e CONJUR_DEPLOYMENT \
     -e RUN_IN_DOCKER \
     -e SUMMON_ENV \

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -1,4 +1,5 @@
 export KEY_VALUE_NOT_EXIST=" "
+mkdir -p output
 
 wait_for_it() {
   local timeout=$1


### PR DESCRIPTION
### What does this PR do?
When running the tests locally it is a good enhancement
to be able to run only a single test. This is now possible using
the `--test-prefix` flag

#### Change log
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR