### PR TITLE
Do not set log level in main

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -22,8 +22,6 @@ func main() {
 
 	log.Info(messages.CSPFK008I, secrets.FullVersionName)
 
-	configureLogLevel()
-
 	// Initialize configurations
 	authnConfig, err := authnConfigProvider.NewFromEnv()
 	if err != nil {
@@ -106,17 +104,6 @@ func provideSecretsToTarget(authn *authenticator.Authenticator, provideConjurSec
 func printErrorAndExit(errorMessage string) {
 	log.Error(errorMessage)
 	os.Exit(1)
-}
-
-func configureLogLevel() {
-	validVal := "true"
-	val := os.Getenv("DEBUG")
-	if val == validVal {
-		log.EnableDebugMode()
-	} else if val != "" {
-		// In case "DEBUG" is configured with incorrect value
-		log.Warn(messages.CSPFK001W, val, validVal)
-	}
 }
 
 func validateContainerMode(containerMode string) {

--- a/pkg/log/messages/warn_messages.go
+++ b/pkg/log/messages/warn_messages.go
@@ -1,3 +1,0 @@
-package messages
-
-const CSPFK001W string = "CSPFK001W Incorrect value '%s' provided for enabling debug mode. Allowed value: '%s'"


### PR DESCRIPTION
We now use the authn-client logger and its log level
is set when we create the authnConfig. Thus, setting the
log level in the SP will cause the logger to include two
log messages of `CAKC052 Debug mode is enabled`.