### PR TITLE
Add TEST_PLATFORM param to dev env vars

### DIFF
--- a/bootstrap.env
+++ b/bootstrap.env
@@ -15,6 +15,7 @@ export APP_NAMESPACE_NAME=app-$UNIQUE_TEST_ID
 # Local DEV Env (uncomment all lines if using this configuration)
 #######
 # export PLATFORM=kubernetes
+# export TEST_PLATFORM=gke
 # export AUTHENTICATOR_ID=authn-dev-env
 # export APP_NAMESPACE_NAME=local-secrets-provider
 # export CONJUR_NAMESPACE_NAME=local-conjur


### PR DESCRIPTION
We now require a new param named TEST_PLATFORM so we should add it
to the 'dev' section in the env var file
