### PR TITLE
Updates conjur-authn-k8s version to v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update k8s authenticator client version to
+  [0.19.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0191---2021-02-08),
+  which streamlines the parsing of authentication responses, updates the
+  project Golang version to v1.15, and improves error messaging.
+
 ## [1.1.2] - 2020-01-29
 
 ### Added

--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -77,14 +77,9 @@ func main() {
 
 func provideSecretsToTarget(authn *authenticator.Authenticator, provideConjurSecrets secrets.ProvideConjurSecrets, accessToken *memory.AccessToken) error {
 	log.Info(fmt.Sprintf(messages.CSPFK001I, authn.Config.Username))
-	authnResp, err := authn.Authenticate()
+	err := authn.Authenticate()
 	if err != nil {
 		return log.RecordedError(messages.CSPFK010E)
-	}
-
-	err = authn.ParseAuthenticationResponse(authnResp)
-	if err != nil {
-		return log.RecordedError(messages.CSPFK011E)
 	}
 
 	err = provideConjurSecrets(accessToken)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyberark/conjur-api-go v0.6.0
-	github.com/cyberark/conjur-authn-k8s-client v0.19.0
+	github.com/cyberark/conjur-authn-k8s-client v0.19.1
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cyberark/conjur-api-go v0.6.0 h1:QQYmFRhcCvmtZ9oSRoXCxWb7uRjppfu5lcEw
 github.com/cyberark/conjur-api-go v0.6.0/go.mod h1:uM96pLpckwYYAWRSbrsw+TT0y3kg49QCEGpdpa9dJ34=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0 h1:zHjdKyZ8bu4cRyV3iYMh1/XfIVtTugoiU/CflnboP9Q=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
+github.com/cyberark/conjur-authn-k8s-client v0.19.1 h1:/o7De4Br4p1j2p9gOPQuurkdjypiHlmg+k2GwoGd1ik=
+github.com/cyberark/conjur-authn-k8s-client v0.19.1/go.mod h1:tD6+rie3c7LFclihIzg12vVK6+yKm0NB+3+0Pmau/A4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### What does this PR do?
This change updates the version of cyberark/conjur-authn-k8s-client that
is used by the Secrets Provider to v0.19.1. In this release of
cyberark/conjur-authn-k8s-client, the Authenticate and
ParseAuthenticationResponse methods were combined into a single method,
so calls to the conjur-authn-k8s-client are changed accordingly.

### What ticket does this PR close?
Resolves #286 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation