### PR TITLE
Login to the registry url which we pull images from

### DIFF
--- a/deploy/1_check_dependencies.sh
+++ b/deploy/1_check_dependencies.sh
@@ -18,6 +18,8 @@ check_env_var "APP_NAMESPACE_NAME"
 if [[ "${DEV}" = "false" ]]; then
   check_env_var "DOCKER_REGISTRY_PATH"
   check_env_var "DOCKER_REGISTRY_URL"
+  check_env_var "PULL_DOCKER_REGISTRY_PATH"
+  check_env_var "PULL_DOCKER_REGISTRY_URL"
 
   if [[ "$PLATFORM" = "openshift" ]]; then
     check_env_var "OPENSHIFT_USERNAME"

--- a/deploy/platform_login.sh
+++ b/deploy/platform_login.sh
@@ -12,7 +12,7 @@ main() {
       $GCLOUD_CLUSTER_NAME \
       --zone $GCLOUD_ZONE \
       --project $GCLOUD_PROJECT_NAME
-    docker login $DOCKER_REGISTRY_PATH \
+    docker login $PULL_DOCKER_REGISTRY_URL \
       -u oauth2accesstoken \
       -p "$(gcloud auth print-access-token)"
   elif [[ "$PLATFORM" = "openshift" ]]; then


### PR DESCRIPTION
We had some issues where we sometimes failed to pull images. This may
be caused by the fact that we log into one registry and pull the SP
image from another.

In OCP 4.5 we changed the registry that we pull images from to our internal registry. We now also login to that registry.