### PR TITLE
Bump version 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.3] - 2021-03-01
 ### Changed
 - Update k8s authenticator client version to
   [0.19.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0191---2021-02-08),
@@ -100,7 +101,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.0.0...v1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # =================== BASE BUILD LAYER ===================
 # this layer is used to prepare a common layer for both debug and release builds
-FROM golang:1.13 as secrets-provider-builder-base
+FROM golang:1.15 as secrets-provider-builder-base
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,5 +1,5 @@
-FROM golang:1.12.0-alpine3.9
-MAINTAINER Conjur Inc.
+FROM golang:1.15-alpine
+MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-junit-processor"
 
 WORKDIR /test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
-FROM golang:1.12.0-alpine3.9
-MAINTAINER Conjur Inc.
+FROM golang:1.15-alpine
+MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-test-runner"
 
 WORKDIR /secrets-provider-for-k8s

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -8,7 +8,7 @@ of the license associated with each component.
 
 Section 1: Apache-2.0
 >>> github.com/cyberark/conjur-api-go - v0.6.0
->>> github.com/cyberark/conjur-authn-k8s-client - v0.19.0
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.19.1
 >>> github.com/googleapis/gnostic - v0.3.1
 >>> github.com/modern-go/reflect2 - v1.0.1
 >>> gopkg.in/yaml.v2 - v2.3.0
@@ -57,7 +57,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/cyberark/conjur-authn-k8s-client - v0.19.0
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.19.1
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.2'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.3'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.1.2
+version: 1.1.3
 home: https://github.com/cyberark/secrets-provider-for-k8s

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: cyberark/secrets-provider-for-k8s
-  tag: 1.1.2
+  tag: 1.1.3
   imagePullPolicy: IfNotPresent
   name: cyberark-secrets-provider-for-k8s
 

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.1.2"
+var Version = "1.1.3"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### What does this PR do?
Dockerfile Go versions bumped to 1.15
Project version bumped to 1.1.3

### What ticket does this PR close?
Resolves #305 
Resolves #278

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation