### PR TITLE
Add support for newer openshift labels in test infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [1.1.3] - 2021-03-01
+
+### Added
+- Verified compatibility for OpenShift 4.6.
+  [cyberark/secrets-provider-for-k8s#265](https://github.com/cyberark/secrets-provider-for-k8s/issues/302)
+
 ### Changed
 - Updated k8s authenticator client version to
   [0.19.1](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CHANGELOG.md#0191---2021-02-08),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,8 @@ To follow [Go testing conventions](https://golang.org/pkg/cmd/go/internal/test/)
 Our integration tests can be run against either a GKE / Openshift remote cluster. To do so, run `./bin/start` and add the proper flags. 
 
 To deploy OSS / DAP, add the `--oss` / `--dap` flags to the above command. By default, the integration tests run DAP, so no flag is required.
-To deploy on GKE / Openshift, add `--gke` / `--oc311` / `--oc45`. By default, the integration tests run on a GKE cluster, so no flag is required.
+To deploy on GKE, add `--gke`. For Openshift, use `--oldest` / `--current` / `--next`. By default, the integration tests run on a GKE cluster,
+so no flag is required.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To deploy the CyberArk Secrets Provider for Kubernetes as an application contain
 
 - K8s 1.11+
 
-- Openshift 3.11 and 4.5 _*(Conjur Enterprise only)*_
+- Openshift 3.11, 4.5, and 4.6 _*(Conjur Enterprise only)*_
 
 ## Using secrets-provider-for-k8s with Conjur OSS 
 

--- a/bin/start
+++ b/bin/start
@@ -20,9 +20,13 @@ Usage: ./bin/start [options]
 
     --gke         Run the integration tests on GKE. By default the tests are run on GKE.
 
-    --oc311       Run the integration tests on Openshift v3.11. By default the tests are run on GKE.
+    --oc311 Run the integration tests on Openshift v3.11. By default the tests are run on GKE.
 
-    --oc45       Run the integration tests on Openshift v4.5. By default the tests are run on GKE.
+    --oldest      Run the integration tests on the oldest running Openshift platform. By default the tests are run on GKE.
+
+    --current     Run the integration tests on the currently supported Openshift platform. By default the tests are run on GKE.
+
+    --next        Run the integration tests on the latest Openshift platform. By default the tests are run on GKE.
 
     -h, --help    Shows this help message.
 EOF
@@ -30,7 +34,7 @@ EOF
 }
 
 runScriptWithSummon() {
-    summon --environment $SUMMON_ENV -f ./summon/secrets.yml $1
+    summon --provider summon-conjur --environment $SUMMON_ENV -f ./summon/secrets.yml $1
 }
 
 RUN_IN_DOCKER=false
@@ -49,7 +53,9 @@ while true ; do
     --dap ) CONJUR_DEPLOYMENT=dap ; shift ;;
     --gke ) SUMMON_ENV=gke ; shift ;;
     --oc311 ) SUMMON_ENV=oc311 ; shift ;;
-    --oc45 ) SUMMON_ENV=oc45 ; shift ;;
+    --oldest ) SUMMON_ENV=oldest ; shift ;;
+    --current ) SUMMON_ENV=current ; shift ;;
+    --next ) SUMMON_ENV=next ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac

--- a/deploy/run_with_summon.sh
+++ b/deploy/run_with_summon.sh
@@ -20,6 +20,10 @@ finish() {
 }
 trap finish EXIT
 
+# Will print platform regardless of GKE or Openshift
+# Will only print version if Openshift
+announce "Running tests on: ${PLATFORM} ${OPENSHIFT_VERSION}"
+
 if [ "${DEV}" = "false" ]; then
   ./platform_login.sh
 fi

--- a/deploy/summon/secrets.yml
+++ b/deploy/summon/secrets.yml
@@ -29,7 +29,7 @@ gke:
   PULL_DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev
 
 oc311:
-  OPENSHIFT_VERSION: '3.11'
+  OPENSHIFT_VERSION: "3.11"
   OPENSHIFT_URL: !var ci/openshift/3.11/hostname
   OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
   OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
@@ -41,8 +41,21 @@ oc311:
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
 
-oc45:
-  OPENSHIFT_VERSION: '4.5'
+oldest:
+  OPENSHIFT_VERSION: !var ci/openshift/oldest/version
+  OPENSHIFT_URL: !var ci/openshift/oldest/hostname
+  OPENSHIFT_USERNAME: !var ci/openshift/oldest/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/oldest/password
+
+  PLATFORM: openshift
+  TEST_PLATFORM: openshift
+  DOCKER_REGISTRY_URL: !var ci/openshift/oldest/registry-url
+  DOCKER_REGISTRY_PATH: !var ci/openshift/oldest/registry-url
+  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/oldest/registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/oldest/registry-url
+
+current:
+  OPENSHIFT_VERSION: !var ci/openshift/current/version
   OPENSHIFT_URL: !var ci/openshift/current/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/current/username
   OPENSHIFT_PASSWORD: !var ci/openshift/current/password
@@ -50,8 +63,23 @@ oc45:
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/current/username
 
   PLATFORM: openshift
-  TEST_PLATFORM: openshift45
+  TEST_PLATFORM: openshift
   DOCKER_REGISTRY_URL: !var ci/openshift/current/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/current/registry-url
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/current/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
+
+next:
+  OPENSHIFT_VERSION: !var ci/openshift/next/version
+  OPENSHIFT_URL: !var ci/openshift/next/api-url
+  OPENSHIFT_USERNAME: !var ci/openshift/next/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/next/password
+  OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/next/username
+  OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/next/username
+
+  PLATFORM: openshift
+  TEST_PLATFORM: openshift
+  DOCKER_REGISTRY_URL: !var ci/openshift/next/registry-url
+  DOCKER_REGISTRY_PATH: !var ci/openshift/next/registry-url
+  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/next/internal-registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/next/internal-registry-url


### PR DESCRIPTION
### What does this PR do?
We now support running tests against the 'next', 'current', and 'oldest' versions of Openshift, as defined in Conjurops.

Currently, only 'current' and 'next' are supported

### What ticket does this PR close?
Resolves #302 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation