### PR TITLE
Adds default-branch to enforce-rebase GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
         fetch-depth: 0
     - name: Is Rebased on main?
       uses: cyberark/enforce-rebase@v2
+      with:
+        default-branch: main
 
   commit_style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
This change adds a `default-branch` setting to the `enforce-rebase` GitHub
action. Without this change, the `enforce-rebase` GH action is failing, e.g.:
```
Error: Invalid return code for message
Error: Pull request must be rebased on master: Command failed: [ "$(git merge-base origin/master HEAD)" = "$(git rev-parse origin/master)" ]
```

### What ticket does this PR close?
Resolves #

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation