### PR TITLE
Update RH base image to UBI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update RH base image to `ubi8/ubi` instead of `rhel7/rhel`.
+  [PR cyberark/secrets-provider-for-k8s#328](https://github.com/cyberark/secrets-provider-for-k8s/pull/328)
+
 ## [1.1.3] - 2021-03-01
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ CMD ["/usr/local/bin/dlv",  \
      "/usr/local/bin/secrets-provider"]
 
 # =================== MAIN CONTAINER (REDHAT) ===================
-FROM registry.access.redhat.com/rhel as secrets-provider-for-k8s-redhat
+FROM registry.access.redhat.com/ubi8/ubi as secrets-provider-for-k8s-redhat
 MAINTAINER CyberArk Software Ltd.
 
 ARG VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,17 @@ pipeline {
                 scanAndReport("secrets-provider-for-k8s:latest", "NONE", true)
               }
             }
+            stage('Scan RedHat image for fixable issues') {
+              steps {
+                scanAndReport("secrets-provider-for-k8s-redhat:latest", "HIGH", false)
+              }
+            }
+    
+            stage('Scan RedHat image for all issues') {
+              steps {
+                scanAndReport("secrets-provider-for-k8s-redhat:latest", "NONE", true)
+              }
+            }
           }
         }
 

--- a/bin/build
+++ b/bin/build
@@ -48,6 +48,7 @@ else
      --build-arg TAG=$(git_tag) \
      --build-arg VERSION="$FULL_VERSION_TAG" \
      --tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" \
+     --tag "secrets-provider-for-k8s-redhat:latest" \
      --target "secrets-provider-for-k8s-redhat" \
      .
 fi


### PR DESCRIPTION
### What does this PR do?
Changes RH base image to use `ubi8/ubi` instead of `rhel7/rhel`. The `rhel7/rhel` base image we've been using has a [CVE](https://access.redhat.com/security/cve/cve-2021-27219) and no updated image in sight. 

Also adds Trivy scans of the RH image to the project.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation