### PR TITLE
Update README to refer to the former version as DAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 # CyberArk Secrets Provider for Kubernetes
 
 The CyberArk Secrets Provider for Kubernetes enables Conjur Enterprise
- (formerly known as Conjur Enterprise) to retrieve secrets stored and managed in the CyberArk Vault.
+ (formerly known as DAP) to retrieve secrets stored and managed in the CyberArk Vault.
  The secrets can be consumed by your Kubernetes or Openshift application containers.
  To retrieve the secrets from Conjur or Conjur Enterprise, 
  the CyberArk Secrets Provider for Kubernetes runs as an init container or application


### PR DESCRIPTION
### What does this PR do?
The naming was updated in [314](https://github.com/cyberark/secrets-provider-for-k8s/pull/314)
to reflect renaming DAP to Conjur Enterprise, however in this case the references the previous name
should remain as DAP.

### What ticket does this PR close?
Resolves NA

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation