### PR TITLE
Adds Helm option to use independently installed Conjur connect ConfigMap

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -1,0 +1,33 @@
+name: Helm Unit Test
+
+on:
+  # Run this on pushes to main
+  push:
+    branches:
+    - main
+
+  # Or when PR operations are done
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+jobs:
+  unit_test:
+    name: Run Helm unittest and Schema Validation Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.3
+
+      - name: Run Helm unittest
+        run: cd ./helm/secrets-provider/tests && ./test-unit
+
+      - name: Run Helm schema validation tests
+        run: cd ./helm/secrets-provider/tests && ./test-schema

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -3,3 +3,4 @@ description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
 version: 1.1.4
 home: https://github.com/cyberark/secrets-provider-for-k8s
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/templates/cert-config-map.yaml
+++ b/helm/secrets-provider/templates/cert-config-map.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.environment.conjur.conjurConnConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   ssl-certificate: {{ .Values.environment.conjur.sslCertificate.value | quote }}
+{{- end }}

--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -41,6 +41,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 
+        {{- if not .Values.environment.conjur.conjurConnConfigMap }}
         - name: CONJUR_APPLIANCE_URL
           value:  {{ .Values.environment.conjur.applianceUrl | quote }}
 
@@ -55,6 +56,7 @@ spec:
             configMapKeyRef:
               name: {{ .Values.environment.conjur.sslCertificate.name | quote }}
               key: ssl-certificate
+        {{- end }}
 
         - name: CONJUR_AUTHN_LOGIN
           value: {{ .Values.environment.conjur.authnLogin | quote }}
@@ -82,6 +84,12 @@ spec:
         {{- if .Values.environment.debug }}
         - name: DEBUG
           value: "true"
+        {{- end }}
+
+        {{- if .Values.environment.conjur.conjurConnConfigMap }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.environment.conjur.conjurConnConfigMap }}
         {{- end }}
       restartPolicy: Never
   backoffLimit: 0

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -1,0 +1,136 @@
+# Helm unit test to be used with the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+suite: test secrets-provider
+
+templates:
+  - secrets-provider.yaml
+
+# Default testing values for required chart values
+defaults: &defaultRequired
+  environment.conjur.account: myConjurAccount
+  environment.conjur.applianceUrl: https://conjur.example.com
+  environment.conjur.authnLogin: host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id
+  environment.conjur.authnUrl: https://conjur.example.com/authn-k8s/my-authn-id
+  environment.conjur.sslCertificate.value: "-----BEGIN CERTIFICATE-----\n
+  MIIC/ThisIsAFakeThisIsOnlyAFake==\n
+  -----END CERTIFICATE-----\n"
+  environment.k8sSecrets: [k8s-secret1,k8s-secret2]
+
+tests:
+  #=======================================================================
+  - it: succeeds if all required values are provided including Conjur
+        connect params
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    asserts:
+      # Confirm that a Secrets Provider Job manifest has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+
+      # Confirm that required values that were explicitly set have been used
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: CONJUR_ACCOUNT
+              value: myConjurAccount
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: CONJUR_APPLIANCE_URL
+              value: https://conjur.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: CONJUR_AUTHN_LOGIN
+              value: host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: CONJUR_AUTHN_URL
+              value: https://conjur.example.com/authn-k8s/my-authn-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: CONJUR_SSL_CERTIFICATE
+              valueFrom:
+                  configMapKeyRef:
+                      key: ssl-certificate
+                      name: cert-config-map
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: K8S_SECRETS
+              value: k8s-secret1,k8s-secret2
+
+      # Confirm that default chart values have been used
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: cyberark/secrets-provider-for-k8s:1.1.4
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: cyberark-secrets-provider-for-k8s
+
+  #=======================================================================
+  - it: succeeds if Conjur connect ConfigMap provided instead of Conjur
+        connect params
+  #=======================================================================
+    set:
+      # Set required values including Conjur connect ConfigMap
+      environment.conjur.authnLogin: host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id
+      environment.conjur.conjurConnConfigMap: conjur-connect
+      environment.k8sSecrets: [k8s-secret1,k8s-secret2]
+
+    asserts:
+      # Confirm that a Secrets Provider Job manifest has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+
+      # Confirm that required values that were explicitly set have been used
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+              configMapRef:
+                  name: conjur-connect
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+              name: K8S_SECRETS
+              value: k8s-secret1,k8s-secret2
+
+  #=======================================================================
+  - it: allows Secrets Provider image spec to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Explicitly set Secrets Provider image specifications and container name
+      secretsProvider.image: my-docker-org/my-docker-image
+      secretsProvider.tag: latest
+      secretsProvider.imagePullPolicy: Always
+      secretsProvider.name: my-container-name
+
+    asserts:
+      # Confirm that explicit image settings have been used
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-docker-org/my-docker-image:latest
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: my-container-name

--- a/helm/secrets-provider/tests/test-schema
+++ b/helm/secrets-provider/tests/test-schema
@@ -1,0 +1,265 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values as defined in the
+# Helm chart's 'values.schema.json' file.
+#
+# This test uses 'helm lint ...' instead of 'helm unittest ...' because the
+# Helm unittest plugin is apparently agnostic to schema restrictions defined
+# in 'values.schema.json'. For example, when required chart settings are not
+# provided, Helm unittest does not capture this as a schema violation, but
+# instead results in a vague null pointer error in Helm. For this reason,
+# Helm unittest is not well suited for negative schema test scenarios.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+# Execute from the parent (chart) directory as required to run 'helm lint ...'
+cd "../$(dirname "$0")"
+
+source ./tests/utils.sh
+
+# Default testing values for required chart values
+readonly DEFAULT_ACCOUNT_SETTING='environment.conjur.account=myConjurAccount'
+readonly DEFAULT_APPLIANCE_URL_SETTING='environment.conjur.applianceUrl=https://conjur.example.com'
+readonly DEFAULT_AUTHN_LOGIN_SETTING='environment.conjur.authnLogin=host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id'
+readonly DEFAULT_AUTHN_URL_SETTING='environment.conjur.authnUrl=https://conjur.example.com/authn-k8s/my-authn-id'
+readonly DEFAULT_SSL_CERT_SETTING='environment.conjur.sslCertificate.value="-----BEGIN CERTIFICATE-----\n
+MIIC/ThisIsAFakeThisIsOnlyAFake==\n
+-----END CERTIFICATE-----\n'
+readonly DEFAULT_K8S_SECRETS_SETTING='environment.k8sSecrets={k8s-secret1\,k8s-secret2}'
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function conjur_account_test() {
+    helm lint . --strict \
+        --set "environment.conjur.account=$1" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_account_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function conjur_url_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "environment.conjur.applianceUrl=$1" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_url_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function conjur_authn_login_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "environment.conjur.authnLogin=$1" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_authn_login_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function conjur_authn_url_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "environment.conjur.authnUrl=$1" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_authn_url_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function conjur_ssl_cert_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "environment.conjur.sslCertificate.value=\"$1\"" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_ssl_cert_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function k8s_secrets_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "environment.k8sSecrets=$1"
+}
+
+function missing_k8s_secrets_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING"
+}
+
+function conjur_conn_configmap_test() {
+    helm lint . --strict \
+        --set "environment.conjur.conjurConnConfigMap=$1" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function missing_conjur_conn_configmap_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING"
+}
+
+function main() {
+    banner $BOLD "Running Helm schema tests for chart \"conjur-config-cluster-prep\""
+    check_helm_version
+
+    announce "Valid Conjur account is accepted"
+    conjur_account_test "a-valid-account"
+    update_results "$?" 
+
+    announce "Null-string Conjur account is rejected"
+    conjur_account_test ""
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Missing Conjur account causes failure"
+    missing_conjur_account_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur URL that begins with 'https://' is accepted"
+    conjur_url_test "https://example.com"
+    update_results "$?" 
+
+    announce "Conjur URL that begins with "HTTPS://" is accepted"
+    conjur_url_test "https://example.com"
+    update_results "$?" 
+
+    announce "Conjur URL that is an internal Kubernetes address is accepted"
+    conjur_url_test "https://conjur.conjur-namespace.svc.cluster.local"
+    update_results "$?" 
+
+    announce "Conjur URL that is an IPv4 address is accepted"
+    conjur_url_test "https://192.0.2.1:443"
+    update_results "$?" 
+
+    announce "Conjur URL that is an IPv6 address is accepted"
+    conjur_url_test "https://[2001:DB8::1]:443"
+    update_results "$?" 
+
+    announce "Conjur URL that uses 'localhost' is accepted"
+    conjur_url_test "https://localhost:443"
+    update_results "$?" 
+
+    announce "Conjur URL that has an endpoint is accepted"
+    conjur_url_test "https://conjur.example.com/some-endpoint"
+    update_results "$?" 
+
+    announce "Missing Conjur URL causes failure"
+    missing_conjur_url_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Valid Conjur authn login is accepted"
+    conjur_authn_login_test "host/my-authn-id/my-policy/my-host-id"
+    update_results "$?" 
+
+    announce "Null-string Conjur authn login is rejected"
+    conjur_authn_login_test ""
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Missing Conjur authn login causes failure"
+    missing_conjur_authn_login_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur authn URL that begins with 'https://' is accepted"
+    conjur_authn_url_test "https://example.com"
+    update_results "$?" 
+
+    announce "Missing Conjur authn URL causes failure"
+    missing_conjur_authn_url_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Null-string Conjur SSL cert is rejected"
+    conjur_ssl_cert__test ""
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Missing Conjur SSL cert causes failure"
+    missing_conjur_ssl_cert_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Single Kubernetes secret is accepted"
+    k8s_secrets_test "{only-one-k8s-secret}"
+    update_results "$?" 
+
+    announce "Missing Kubernetes secrets list causes failure"
+    missing_k8s_secrets_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Valid Conjur connect ConfigMap name is accepted"
+    conjur_conn_configmap_test "name-with-dashes"
+    update_results "$?"
+
+    announce "Null-string Conjur connect ConfigMap name is rejected"
+    conjur_conn_configmap_test ""
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Missing both Conjur connect info and Conjur connect ConfigMap name causes failure"
+    missing_conjur_configmap_name_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/helm/secrets-provider/tests/test-unit
+++ b/helm/secrets-provider/tests/test-unit
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Execute from the parent (chart) directory as required to run unittest
+cd "../$(dirname "$0")"
+
+source ./tests/utils.sh
+
+banner $BOLD "Running Helm unit tests for chart \"conjur-config-cluster-prep\""
+
+# Install the 'helm-unittest' plugin if it hasn't been install already
+if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then
+    echo "Installing 'helm-unittest' Helm plugin"
+    helm plugin install https://github.com/quintush/helm-unittest
+fi
+
+# Run a Helm unit test
+helm unittest . --helm3

--- a/helm/secrets-provider/tests/utils.sh
+++ b/helm/secrets-provider/tests/utils.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+colorize="${COLORIZE:-true}"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly NOCOLOR='\033[0m'
+readonly BOLD='\e[1m'
+readonly ANNOUNCE_COLOR="$BLUE"
+readonly MIN_HELM_VERSION="3.5.3"
+readonly EXPECT_FAILURE=true
+
+# Set the current text color if colorizing is enabled.
+function set_color() {
+    if [ "$colorize" = true ]; then
+        echo -e "$1"
+    else
+        echo -e ""
+    fi
+}
+
+# If colorizing is enabled, temporarily set the text color, print a string,
+# and then reset the text color, without any intervening newlines. This can
+# be useful for printing just a word or a portion of a line in color. If
+# colorizing is disabled, it simply prints the string.
+function color_text() {
+    if [ "$colorize" = true ]; then
+        echo -en "$1"
+    fi
+    echo "${@:2}"
+    if "$colorize"; then
+        echo -en "$NOCOLOR"
+    fi
+}
+
+# Print a string inside leading and trailing lines of dashes. If colorizing
+# is enabled, print everything in the ANNOUNCE_COLOR.
+function announce() {
+  set_color "$ANNOUNCE_COLOR"
+  echo "---------------------------------------------------------------------"
+  echo -e "$@"
+  echo "---------------------------------------------------------------------"
+  set_color "$NOCOLOR"
+}
+
+# Print a string inside leading and trailing lines of '=' characters. If
+# colorizing is enabled, print everything in a given color.
+function banner() {
+  set_color "$1"
+  echo "====================================================================="
+  echo -e "${@:2}"
+  echo "====================================================================="
+  set_color "$NOCOLOR"
+}
+
+# Compare two semantic versions, and return the oldest of the two.
+function oldest_version() {
+  v1=$1
+  v2=$2
+
+  echo "$(printf '%s\n' "$v1" "$v2" | sort -V | head -n1)"
+}
+
+# Return true if a given semantic version is the same as or newer than
+# a given minimum acceptable version. Return false otherwise.
+function meets_min_version() {
+  actual_version=$1
+  min_version=$2
+
+  oldest="$(oldest_version $actual_version $min_version)"
+  if [ "$oldest" = "$min_version" ]; then
+    true
+  else
+    false
+  fi
+}
+
+function invert_exit_status() {
+    exit_status="$1"
+    if [ "$exit_status" -ne 0 ]; then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
+function update_results() {
+    exit_status="$1"
+    failure_expected="${2:-false}"
+    if [ "$failure_expected" = true ]; then
+        echo "FAILURE EXPECTED"
+        exit_status="$(invert_exit_status $exit_status)"
+    fi
+    if [ "$exit_status" -eq 0 ]; then
+        color_text "$GREEN" "Test Case PASSED!"
+        let "num_passed=num_passed+1"
+    else
+        color_text "$RED" "Test Case FAILED!"
+        let "num_failed=num_failed+1"
+        test_failed=true
+    fi
+}
+
+function display_final_results() {
+    if [ "$num_failed" -eq 0 ]; then
+        result_text="Test PASSED!"
+        result_color="$GREEN"
+    else
+        result_text="Test FAILED!"
+        result_color="$RED"
+    fi
+    banner "$result_color" \
+        "$result_text\n" \
+        "   Passed test cases: $num_passed" \
+        "   Failed test cases: $num_failed"
+}
+
+function check_helm_version() {
+    helm_version="$(helm version --template {{.Version}} | sed 's/^v//')"
+    if ! meets_min_version $helm_version $MIN_HELM_VERSION; then
+        echo "helm version $helm_version is invalid. Version must be $MIN_HELM_VERSION or newer"
+        exit 1
+    fi
+}

--- a/helm/secrets-provider/values.schema.json
+++ b/helm/secrets-provider/values.schema.json
@@ -7,12 +7,6 @@
   ],
   "properties": {
     "rbac": {
-      "required": [
-        "create",
-        "roleName",
-        "roleBindingName",
-        "serviceAccount"
-      ],
       "properties": {
         "create": {
           "type": "boolean"
@@ -26,9 +20,6 @@
           "minLength": 1
         },
         "serviceAccount": {
-          "required": [
-            "name"
-          ],
           "properties": {
             "name": {
               "type": "string",
@@ -39,12 +30,6 @@
       }
     },
     "secretsProvider": {
-      "required": [
-        "image",
-        "tag",
-        "imagePullPolicy",
-        "name"
-      ],
       "properties": {
         "image": {
           "type": "string",
@@ -86,30 +71,47 @@
           }
         },
         "conjur": {
-          "required": [
-            "account",
-            "applianceUrl",
-            "authnUrl",
-            "authnLogin",
-            "sslCertificate"
+          "anyOf": [
+            {
+              "required": [
+                "authnLogin",
+                "conjurConnConfigMap"
+              ]
+            },{
+              "required": [
+                "authnLogin",
+                "account",
+                "applianceUrl",
+                "authnUrl"
+              ],
+              "properties": {
+                "sslCertificate": {
+                  "required": [ "value" ]
+                }
+              }
+            }
           ],
           "properties": {
             "account": {
-              "type": "string",
+              "type": ["string","null"],
               "minLength": 1
             },
             "applianceUrl": {
-              "type": "string",
+              "type": ["string","null"],
               "minLength": 1,
               "pattern": "^https?://[^\\s/$.?#].[^\\s]*$"
             },
             "authnUrl": {
-              "type": "string",
+              "type": ["string","null"],
               "minLength": 1,
               "pattern": "^https?://[^\\s/$.?#].[^\\s]*$"
             },
             "authnLogin": {
               "type": "string",
+              "minLength": 1
+            },
+            "conjurConnConfigMap": {
+              "type": ["string","null"],
               "minLength": 1
             },
             "retryIntervalSec": {
@@ -122,17 +124,13 @@
             },
             "sslCertificate": {
               "type": "object",
-              "required": [
-                "name",
-                "value"
-              ],
               "properties": {
                 "name": {
-                  "type": "string",
+                  "type": ["string"],
                   "minLength": 1
                 },
                 "value": {
-                  "type": "string",
+                  "type": ["string","null"],
                   "minLength": 1
                 }
               }

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -21,21 +21,63 @@ labels: {}
 annotations: {}
 
 environment:
-  # Array of Kubernetes Secret names that applications consume, and whose value is sourced in DAP/Conjur.
-  # For example, [k8s-secret1,k8s-secret2]
-  k8sSecrets:
+  # Array of Kubernetes Secret names that applications consume, and
+  # whose value is sourced in DAP/Conjur.For example, [k8s-secret1,k8s-secret2]
+  # This setting is required.
+  #
+  # k8sSecrets:
+
   conjur:
+    # There are two ways that you can supply the necessary configuration to
+    # allow Secrets Provider to connect with Conjur (listed in order of
+    # precedence):
+    #
+    # 1. Using a Conjur connection ConfigMap that has been installed
+    #    independently of this Helm chart, that contains the following
+    #    connection parameters:
+    #      CONJUR_ACCOUNT
+    #      CONJUR_APPLIANCE_URL
+    #      CONJUR_AUTHENTICATOR_ID
+    #      CONJUR_AUTHN_URL
+    #      CONJUR_SSL_CERTIFICATE
+    #    To make use of an existing Conjur Connection ConfigMap, set this
+    #    chart value:
+    #      environment.conjur.conjurConnConfigMap
+    #
+    # 2. Providing the connection parameters directly by setting the following
+    #    chart values:
+    #      environment.conjur.account
+    #      environment.conjur.applianceUrl
+    #      environment.conjur.authnUrl
+    #      environment.conjur.sslCertificate.*
+    #
+    # conjurConnConfigMap:
+
     # DAP/Conjur account name as defined during initial DAP/Conjur configuration.
-    account:
+    # This setting is required if 'conjurConnConfigMap' is not set.
+    #
+    # account:
+    
     # URL of service defined for DAP Follower/Conjur.
-    applianceUrl:
+    # This setting is required if 'conjurConnConfigMap' is not set.
+    #
+    # applianceUrl:
+ 
     # URL for the Kubernetes authenticator with which the Secrets Provider will authenticate.
-    authnUrl:
-    # Host that authenticates Secrets Provider to DAP/Conjur.
-    authnLogin:
+    # This setting is required if 'conjurConnConfigMap' is not set.
+    #
+    # authnUrl:
+ 
     sslCertificate:
       # Name of ConfigMap that holds the public SSL certificate required for connecting to Follower/Conjur.
       name: cert-config-map
+
       # Value that stores the public SSL certificate required for connecting to Follower/Conjur.
-      # This value should be passed in when installing the chart.
-      value:
+      # This setting is required if 'conjurConnConfigMap' is not set.
+      #
+      # value:
+
+    # : Host that authenticates Secrets Provider to DAP/Conjur.
+    # This setting is required.
+    #
+    # authnLogin:


### PR DESCRIPTION
### What does this PR do?

This change adds the following for the Secrets Provider stand-alone mode
Helm chart:

- A Helm chart value for allowing the Secrets Provider to get its Conjur
  connection information via an independently installed (i.e. outside of this Helm
  chart) Conjur connection info ConfigMap, instead of using Pod environment variables.
  This will allow this Helm chart to be used in conjunction with the Kubernetes cluster
   prep Helm chart and the application Namespace prep Helm chart as described here:
  
  - https://github.com/cyberark/conjur-authn-k8s-client/tree/master/helm/conjur-config-namespace-prep
  - https://github.com/cyberark/conjur-authn-k8s-client/tree/master/helm/conjur-config-cluster-prep
  
  If the Conjur connection ConfigMap is configured, the other Conjur connect
  Helm chart settings are ignored.

- Adds Helm unit tests that make use of the 'helm-unittest' plugin. See:
  https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md

- Adds Helm schema validation tests based upon `helm lint ...`.

- In `values.yaml`, the required settings are commented out. This is done
  in order for the `required` settings in `values.schema.json` to take
  effect, so that the error message that is generated when a required
  setting is not provided is abundantly clear that a the required setting
  is missing. Without commenting out these settings in `values.yaml`, the
  Helm `values.schema.json` validation interprets these settings as always
  being "set".

- In `values.schema.json`, for any settings that have default values
  defined in `values.yaml`, the `required` settings in
  `values.schema.json` are deleted, since these settings will never
  be unset due to their default settings.

- Adds a GitHub action for running the Helm unittest and the Helm
   schema validation test.

### What ticket does this PR close?

This PR is a pre-requisite change for a couple of issues in the cyberark/conjur-authn-k8s-client repository:

- https://github.com/cyberark/conjur-authn-k8s-client/issues/273
- https://github.com/cyberark/conjur-authn-k8s-client/issues/292

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation