### PR TITLE
Adds Helm chart option to set Secrets Provider Job name

### DIFF
--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.secretsProvider.jobName | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 {{- with .Values.labels }}
   labels:

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -134,3 +134,37 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].name
           value: my-container-name
+
+  #=======================================================================
+  - it: uses the Helm Release name as a Secrets Provider Job name by default
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    asserts:
+      # Confirm that the Secrets Provider Job name is set to Release name
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+
+  #=======================================================================
+  - it: uses the Secrets Provider Job name chart value if explicitly set
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Explicitly Set the Secrets Provider Job name
+      secretsProvider.jobName: my-secrets-provider-job-name
+
+    asserts:
+      # Confirm that the Secrets Provider Job name is set to the configured
+      # chart value
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: my-secrets-provider-job-name

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -14,7 +14,10 @@ secretsProvider:
   image: cyberark/secrets-provider-for-k8s
   tag: 1.1.4
   imagePullPolicy: IfNotPresent
+  # Container name
   name: cyberark-secrets-provider-for-k8s
+  # Optional: Kubernetes Job name. Defaults to Helm Release.
+  jobName:
 
 # OPTIONAL: Additional labels to apply to Job resource.
 labels: {}


### PR DESCRIPTION
### What does this PR do?

Currently, the Secrets Provider Helm chart deploys a Secrets Provider
Kubernetes Job with a name that is (unconditionally) set to the Helm Release
name. This should work fine in most cases.

In the case where the Secrets Provider Helm chart is included as a
[Helm dependency](https://helm.sh/docs/helm/helm_dependency) to another
(parent) Helm chart, however, the Secrets Provider Helm chart inherits its Release
name from its parent chart. This currently results in the Secrets Provider
Job name being set to the Release name of the **parent** Helm chart, which
is a bit confusing. This is a scenario we're seeing in adding a workflow
to test Secrets Provider as a standalone job with the
[Conjur authn-k8s client E2E workflow Helm charts](https://github.com/cyberark/conjur-authn-k8s-client/tree/master/helm/conjur-app-deploy). 

This change adds a chart value to allow the Secrets Provider Kubernetes Job
to be explicitly set, if desired. If this chart value is not set explicitly,
then the Secrets Provider Kubernetes Job name will default to the chart's
Release name.

This change also includes a couple of Helm unittest test cases to test
the precedence ordering for the SP Job name.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation