### PR TITLE
Bump version to 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.5] - 2021-08-13
+
+### Added
+- Adds Helm chart option to use an independently installed Conjur Connect
+  ConfigMap instead of configuring Conjur connection parameters via environment
+  variables.
+  [cyberark/secrets-provider-for-k8s#349](https://github.com/cyberark/secrets-provider-for-k8s/pull/349)
+- Adds Helm chart option to explicitly set the Secrets Provider Job name.
+  [cyberark/secrets-provider-for-k8s#352](https://github.com/cyberark/secrets-provider-for-k8s/pull/352)
+
 ### Security
 - Upgrades base Alpine image used for Secrets Provider container image to
   v3.14 to resolve CVE-2021-36159.
@@ -118,7 +128,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.1...v1.1.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,7 @@ follow the instructions in this section.
     1. [Version file](pkg/secrets/version.go)
     1. [Chart version](helm/secrets-provider/Chart.yaml)
     1. [Default deployed version](helm/secrets-provider/values.yaml)
+    1. [Helm unit test for chart defaults](helm/secrets-provider/tests/secrets_provider_test.yaml)
     1. [Test case hardcoded version](deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh)
 1. Commit these changes - `Bump version to x.y.z` is an acceptable commit
    message - and open a PR for review.

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.4'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.5'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.1.4
+version: 1.1.5
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: cyberark/secrets-provider-for-k8s:1.1.4
+          value: cyberark/secrets-provider-for-k8s:1.1.5
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: cyberark/secrets-provider-for-k8s
-  tag: 1.1.4
+  tag: 1.1.5
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.1.4"
+var Version = "1.1.5"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### What does this PR do?

Bumps Secrets Provider version to `1.1.5`.

This change is being made mostly so that a new Helm chart (with matching Chart version of `1.1.5`) can be published to `cyberark/helm-charts`, making available some new Helm chart options.

This also adds a couple of `CHANGELOG.md` entries to describe new Helm chart options.

### What ticket does this PR close?

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation