### PR TITLE
Upgrades Alpine to v3.14 to resolve CVE-2021-36159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Upgrades base Alpine image used for Secrets Provider container image to
+  v3.14 to resolve CVE-2021-36159.
+  [cyberark/secrets-provider-for-k8s#354](https://github.com/cyberark/secrets-provider-for-k8s/pull/354)
+
 ## [1.1.4] - 2021-06-30
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ FROM busybox
 
 # =================== BASE MAIN CONTAINER ===================
 # this layer is used to prepare a common layer for both debug and release containers
-FROM alpine:3.13 as secrets-provider-base
+FROM alpine:3.14 as secrets-provider-base
 MAINTAINER CyberArk Software Ltd.
 
 # copy a few commands from busybox


### PR DESCRIPTION
### What does this PR do?

The base Alpine image used for the Secrets Provider container image is
upgraded from alpine:3.13 to alpine:3.14 in order to resolve CVE-2021-36159.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation