### PR TITLE
Avoid dockerhub pull limits in Openshift for sleeping container

### DIFF
--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -31,7 +31,7 @@ spec:
     spec:
       serviceAccountName: ${APP_NAMESPACE_NAME}-sa
       containers:
-      - image: debian
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
         name: test-app
         command: ["sleep"]
         args: ["infinity"]

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: ${APP_NAMESPACE_NAME}-sa
       containers:
-      - image: debian
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
         name: test-app
         command: ["sleep"]
         args: ["infinity"]

--- a/deploy/run_with_summon.sh
+++ b/deploy/run_with_summon.sh
@@ -50,6 +50,11 @@ if [ "${DEV}" = "false"  ]; then
     "${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider"
 
   docker push "${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider"
+
+  # Make sure debian is pushed to the internal registry to avoid Dockerhub pull restrictions
+  docker pull debian:latest
+  docker tag debian:latest "${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest"
+  docker push "${DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest"
 else
   docker tag "secrets-provider-for-k8s:dev" \
     "${APP_NAMESPACE_NAME}/secrets-provider"


### PR DESCRIPTION
### What does this PR do?

Change sleeping container image from 'debian' to the image of the secrets provider. This avoids having to push another container and also avoids worrying about dockerhub pull limits. The test app container really just need 
1. to have `sleep` so it can initially sleep
2. to have `cut`, `grep` and `printenv` for making test assertions

### What ticket does this PR close?
Resolves -

Sometimes the build is failing due to errrors of the form
```
Warning  Failed          1m (x3 over 4m)   kubelet, ip-10-0-158-137.ec2.internal  Failed to pull image "debian": rpc error: code = Unknown desc = Error reading manifest latest in docker.io/library/debian: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation