### PR TITLE
Ensure openssl development libraries for alpine are always up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ FROM busybox
 FROM alpine:3.14 as secrets-provider-base
 MAINTAINER CyberArk Software Ltd.
 
+# Ensure openssl development libraries are always up to date
+RUN apk add --no-cache openssl-dev
+
 # copy a few commands from busybox
 COPY --from=busybox /bin/tar /bin/tar
 COPY --from=busybox /bin/sleep /bin/sleep


### PR DESCRIPTION
### What does this PR do?

Ensures openssl development libraries (libcrypto, libssl etc.) for alpine are always up to date. Fixes [CVE-2021-3711](https://nvd.nist.gov/vuln/detail/CVE-2021-3711) in the alpine image this repo uses, but is also forward looking.


### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation