### PR TITLE
Add ocp 4.8.2 cli support for ci against ocp 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for OpenShift 4.8 has been added.
+
 ## [1.1.5] - 2021-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To deploy the CyberArk Secrets Provider for Kubernetes as an application contain
 
 - K8s 1.11+
 
-- Openshift 3.11, 4.5, 4.6, and 4.7 _*(Conjur Enterprise only)*_
+- Openshift 3.11, 4.5, 4.6, 4.7, and 4.8 _*(Conjur Enterprise only)*_
 
 ## Using secrets-provider-for-k8s with Conjur Open Source 
 

--- a/deploy/summon/secrets.yml
+++ b/deploy/summon/secrets.yml
@@ -70,6 +70,7 @@ current:
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
 
 next:
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.2/openshift-client-linux.tar.gz
   OPENSHIFT_VERSION: !var ci/openshift/next/version
   OPENSHIFT_URL: !var ci/openshift/next/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/next/username

--- a/deploy/test/Dockerfile
+++ b/deploy/test/Dockerfile
@@ -21,8 +21,8 @@ RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
     wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
-    tar xvf oc.tar.gz --strip-components=1 -C ocbin && \
-    mv ocbin/oc /usr/local/bin/oc && \
+    tar xvf oc.tar.gz -C ocbin && \
+    cp "$(find ./ocbin -name 'oc' -type f | tail -1)"  /usr/local/bin/oc  && \
     rm -rf ocbin oc.tar.gz
 
 # Install Helm

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: cyberark/secrets-provider-for-k8s:1.1.5
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.1.5
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -11,7 +11,7 @@ rbac:
     name: secrets-provider-service-account
 
 secretsProvider:
-  image: cyberark/secrets-provider-for-k8s
+  image: docker.io/cyberark/secrets-provider-for-k8s
   tag: 1.1.5
   imagePullPolicy: IfNotPresent
   # Container name


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

    Added cli support for testing against OCP 4.8 by implementing v4.8.2 for the cli. Using older 3.* cli threw exceptions
    when describing k8s resources in openshift.

- _How should the reviewer approach this PR, especially if manual tests are required?_

    - Review pipeline (attached to this PR)
    - Review [pipeline with TEST_OCP_NEXT enabled here](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secrets-provider-for-k8s/detail/fix%2Focp-next/2/pipeline/140)
    - Review changes to CHANGELOG

- _Are there relevant screenshots you can add to the PR description?_

    N/A

### What ticket does this PR close?
Resolves ONYX-11430

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or

    The test against the OCP 4.8 (next) cluster is not new, per se, but has not been passing until these changes.

- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation