### PR TITLE
Adds UT for FromFile in annotations package

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	annotationsMap := map[string]string{}
 	if _, err := os.Stat(annotationsFile); err == nil {
-		annotationsMap, err = annotations.FromFile(annotationsFile)
+		annotationsMap, err = annotations.NewAnnotationsFromFile(annotationsFile)
 		if err != nil {
 			printErrorAndExit(messages.CSPFK040E)
 		}


### PR DESCRIPTION
### What does this PR do?

This change adds UT for the FromFile function in the Secrets Provider `annotations` package.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation