### PR TITLE
Adds validation logic for secrets aliases and IDs (Conjur var paths)

### DIFF
--- a/pkg/secrets/pushtofile/standard_templates.go
+++ b/pkg/secrets/pushtofile/standard_templates.go
@@ -17,12 +17,10 @@ func (s standardTemplate) ValidateAlias(alias string) error {
 }
 
 var standardTemplates = map[string]standardTemplate{
-	"yaml": {template: yamlTemplate, validateAlias: func(alias string) error {
-		return nil
-	}},
-	"json":   {template: jsonTemplate},
-	"dotenv": {template: dotenvTemplate},
-	"bash":   {template: bashTemplate},
+	"yaml":   {template: yamlTemplate, validateAlias: validateYAMLKey},
+	"json":   {template: jsonTemplate, validateAlias: validateJSONKey},
+	"dotenv": {template: dotenvTemplate, validateAlias: validateBashVarName},
+	"bash":   {template: bashTemplate, validateAlias: validateBashVarName},
 }
 
 // FileTemplateForFormat returns the template for a file format, after ensuring the

--- a/pkg/secrets/pushtofile/standard_templates_test.go
+++ b/pkg/secrets/pushtofile/standard_templates_test.go
@@ -1,47 +1,75 @@
 package pushtofile
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+const (
+	invalidYAMLChar    = "invalid YAML character"
+	invalidJSONChar    = "invalid JSON character"
+	yamlAliasTooLong   = "too long for YAML"
+	jsonAliasTooLong   = "too long for JSON"
+	invalidBashVarName = "Must be alphanumerics and underscores"
+	validConjurPath    = "valid/conjur/variable/path"
+)
+
+type assertErrorFunc func(*testing.T, error, string)
+
+func assertNoError() assertErrorFunc {
+	return func(t *testing.T, err error, desc string) {
+		assert.NoError(t, err, desc)
+	}
+}
+
+func assertErrorContains(expErrStr string) assertErrorFunc {
+	return func(t *testing.T, err error, desc string) {
+		assert.Error(t, err, desc)
+		assert.Contains(t, err.Error(), expErrStr, desc)
+	}
+}
 
 var standardTemplateTestCases = []pushToWriterTestCase{
 	{
 		description: "json",
-		template: standardTemplates["json"].template,
+		template:    standardTemplates["json"].template,
 		secrets: []*Secret{
 			{Alias: "alias 1", Value: "secret value 1"},
 			{"alias 2", "secret value 2"},
 		},
-		assert:  assertGoodOutput(`{"alias 1":"secret value 1","alias 2":"secret value 2"}`),
+		assert: assertGoodOutput(`{"alias 1":"secret value 1","alias 2":"secret value 2"}`),
 	},
 	{
 		description: "yaml",
-		template: standardTemplates["yaml"].template,
+		template:    standardTemplates["yaml"].template,
 		secrets: []*Secret{
 			{Alias: "alias 1", Value: "secret value 1"},
 			{"alias 2", "secret value 2"},
 		},
-		assert:  assertGoodOutput(`"alias 1": "secret value 1"
+		assert: assertGoodOutput(`"alias 1": "secret value 1"
 "alias 2": "secret value 2"`),
 	},
 	{
 		description: "dotenv",
-		template: standardTemplates["dotenv"].template,
+		template:    standardTemplates["dotenv"].template,
 		secrets: []*Secret{
 			{Alias: "alias1", Value: "secret value 1"},
 			{"alias2", "secret value 2"},
 		},
-		assert:  assertGoodOutput(`alias1="secret value 1"
+		assert: assertGoodOutput(`alias1="secret value 1"
 alias2="secret value 2"`),
 	},
 	{
 		description: "bash",
-		template: standardTemplates["bash"].template,
+		template:    standardTemplates["bash"].template,
 		secrets: []*Secret{
 			{Alias: "alias1", Value: "secret value 1"},
 			{"alias2", "secret value 2"},
 		},
-		assert:  assertGoodOutput(`export alias1="secret value 1"
+		assert: assertGoodOutput(`export alias1="secret value 1"
 export alias2="secret value 2"`),
 	},
 }
@@ -49,5 +77,190 @@ export alias2="secret value 2"`),
 func Test_standardTemplates(t *testing.T) {
 	for _, tc := range standardTemplateTestCases {
 		tc.Run(t)
+	}
+}
+
+type aliasCharTestCase struct {
+	description string
+	testChar    rune
+	assert      assertErrorFunc
+}
+
+func (tc *aliasCharTestCase) Run(t *testing.T, fileFormat string) {
+	t.Run(tc.description, func(t *testing.T) {
+		// Set up test case
+		desc := fmt.Sprintf("%s file format, key containing %s character",
+			fileFormat, tc.description)
+		alias := "key_containing_" + string(tc.testChar) + "_character"
+		secretSpecs := []SecretSpec{{Alias: alias, Path: validConjurPath}}
+
+		// Run test case
+		_, err := FileTemplateForFormat(fileFormat, secretSpecs)
+
+		// Check result
+		tc.assert(t, err, desc)
+	})
+}
+
+type aliasLenTestCase struct {
+	description string
+	alias       string
+	assert      assertErrorFunc
+}
+
+func (tc *aliasLenTestCase) Run(t *testing.T, fileFormat string) {
+	t.Run(tc.description, func(t *testing.T) {
+		// Set up test case
+		desc := fmt.Sprintf("%s file format, %s", fileFormat, tc.description)
+		secretSpecs := []SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
+
+		// Run test case
+		_, err := FileTemplateForFormat(fileFormat, secretSpecs)
+
+		// Check result
+		tc.assert(t, err, desc)
+	})
+}
+
+func TestValidateAliasForYAML(t *testing.T) {
+	testValidateAliasCharForYAML(t)
+	testValidateAliasLenForYAML(t)
+}
+
+func testValidateAliasCharForYAML(t *testing.T) {
+	testCases := []aliasCharTestCase{
+		// YAML file format, 8-bit characters
+		{"printable ASCII", '\u003F', assertNoError()},
+		{"heart emoji", '💙', assertNoError()},
+		{"dog emoji", '🐶', assertNoError()},
+		{"ASCII NULL", '\u0000', assertErrorContains(invalidYAMLChar)},
+		{"ASCII BS", '\u0008', assertErrorContains(invalidYAMLChar)},
+		{"ASCII tab", '\u0009', assertNoError()},
+		{"ASCII LF", '\u000A', assertNoError()},
+		{"ASCII VT", '\u000B', assertErrorContains(invalidYAMLChar)},
+		{"ASCII CR", '\u000D', assertNoError()},
+		{"ASCII space", '\u0020', assertNoError()},
+		{"ASCII tilde", '\u007E', assertNoError()},
+		{"ASCII DEL", '\u007F', assertErrorContains(invalidYAMLChar)},
+		// YAML file format, 16-bit Unicode
+		{"Unicode NEL", '\u0085', assertNoError()},
+		{"Unicode 0x86", '\u0086', assertErrorContains(invalidYAMLChar)},
+		{"Unicode 0x9F", '\u009F', assertErrorContains(invalidYAMLChar)},
+		{"Unicode 0xA0", '\u00A0', assertNoError()},
+		{"Unicode 0xD7FF", '\uD7FF', assertNoError()},
+		{"Unicode 0xE000", '\uE000', assertNoError()},
+		{"Unicode 0xFFFD", '\uFFFD', assertNoError()},
+		{"Unicode 0xFFFE", '\uFFFE', assertErrorContains(invalidYAMLChar)},
+		// YAML file format, 32-bit Unicode
+		{"Unicode 0x10000", '\U00010000', assertNoError()},
+		{"Unicode 0x10FFFF", '\U0010FFFF', assertNoError()},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t, "yaml")
+	}
+}
+
+func testValidateAliasLenForYAML(t *testing.T) {
+	maxLenAlias := strings.Repeat("a", maxYAMLKeyLen)
+
+	testCases := []aliasLenTestCase{
+		{"single char alias", "a", assertNoError()},
+		{"maximum length alias", maxLenAlias, assertNoError()},
+		{"oversized alias", maxLenAlias + "a", assertErrorContains(yamlAliasTooLong)},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t, "yaml")
+	}
+}
+
+func TestValidateAliasForJSON(t *testing.T) {
+	testValidateAliasCharForJSON(t)
+	testValidateAliasLenForJSON(t)
+}
+
+func testValidateAliasCharForJSON(t *testing.T) {
+	testCases := []aliasCharTestCase{
+		// JSON file format, valid characters
+		{"ASCII space", '\u0020', assertNoError()},
+		{"ASCII tilde", '~', assertNoError()},
+		{"heart emoji", '💙', assertNoError()},
+		{"dog emoji", '🐶', assertNoError()},
+		{"Unicode 0x10000", '\U00010000', assertNoError()},
+		{"Unicode 0x10FFFF", '\U0010FFFF', assertNoError()},
+		// JSON file format, invalid characters
+		{"ASCII NUL", '\u0000', assertErrorContains(invalidJSONChar)},
+		{"ASCII 0x1F", '\u001F', assertErrorContains(invalidJSONChar)},
+		{"ASCII NULL", '\u0000', assertErrorContains(invalidJSONChar)},
+		{"ASCII BS", '\u0008', assertErrorContains(invalidJSONChar)},
+		{"ASCII tab", '\u0009', assertErrorContains(invalidJSONChar)},
+		{"ASCII LF", '\u000A', assertErrorContains(invalidJSONChar)},
+		{"ASCII VT", '\u000B', assertErrorContains(invalidJSONChar)},
+		{"ASCII DEL", '\u007F', assertErrorContains(invalidJSONChar)},
+		{"ASCII quote", '"', assertErrorContains(invalidJSONChar)},
+		{"ASCII backslash", '\\', assertErrorContains(invalidJSONChar)},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t, "json")
+	}
+}
+
+func testValidateAliasLenForJSON(t *testing.T) {
+	maxLenAlias := strings.Repeat("a", maxJSONKeyLen)
+
+	testCases := []aliasLenTestCase{
+		{"single-char alias", "a", assertNoError()},
+		{"maximum length alias", maxLenAlias, assertNoError()},
+		{"oversized alias", maxLenAlias + "a", assertErrorContains(jsonAliasTooLong)},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t, "json")
+	}
+}
+
+func TestValidateAliasForBash(t *testing.T) {
+	testValidateAliasForBashOrDotenv(t, "bash")
+}
+
+func TestValidateAliasForDotenv(t *testing.T) {
+	testValidateAliasForBashOrDotenv(t, "dotenv")
+}
+
+func testValidateAliasForBashOrDotenv(t *testing.T, fileFormat string) {
+	testCases := []struct {
+		description string
+		alias       string
+		assert      assertErrorFunc
+	}{
+		// Bash file format, valid aliases
+		{"all lower case chars", "foobar", assertNoError()},
+		{"all upper case chars", "FOOBAR", assertNoError()},
+		{"upper case, lower case, and underscores", "_Foo_Bar_", assertNoError()},
+		{"leading underscore with digits", "_12345", assertNoError()},
+		{"upper case, lower case, underscores, digits", "_Foo_Bar_1234", assertNoError()},
+
+		// Bash file format, invalid aliases
+		{"leading digit", "7th_Heaven", assertErrorContains(invalidBashVarName)},
+		{"spaces", "FOO BAR", assertErrorContains(invalidBashVarName)},
+		{"dashes", "FOO-BAR", assertErrorContains(invalidBashVarName)},
+		{"single quotes", "FOO_'BAR'", assertErrorContains(invalidBashVarName)},
+		{"dog emoji", "FOO_'🐶'_BAR", assertErrorContains(invalidBashVarName)},
+		{"trailing space", "FOO_BAR ", assertErrorContains(invalidBashVarName)},
+	}
+
+	for _, tc := range testCases {
+		// Set up test case
+		desc := fmt.Sprintf("%s file format, alias with %s",
+			fileFormat, tc.description)
+		secretSpecs := []SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
+
+		// Run test case
+		_, err := FileTemplateForFormat(fileFormat, secretSpecs)
+
+		// Check result
+		tc.assert(t, err, desc)
 	}
 }

--- a/pkg/secrets/pushtofile/standard_templates_validate.go
+++ b/pkg/secrets/pushtofile/standard_templates_validate.go
@@ -1,0 +1,90 @@
+package pushtofile
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	maxYAMLKeyLen = 1024
+	maxJSONKeyLen = 2097152
+)
+
+func validateYAMLKey(key string) error {
+	if len(key) > maxYAMLKeyLen {
+		return fmt.Errorf("the key '%s' is too long for YAML", key)
+	}
+	for _, c := range key {
+		if !isValidYAMLChar(c) {
+			return fmt.Errorf("invalid YAML character: '%c'", c)
+		}
+	}
+	return nil
+}
+
+func isValidYAMLChar(c rune) bool {
+	// Checks whether a character is in the YAML valid character set as
+	// defined here: https://yaml.org/spec/1.2.2/#51-character-set
+	switch {
+	case c == '\u0009':
+		return true // tab
+	case c == '\u000A':
+		return true // LF
+	case c == '\u000D':
+		return true // CR
+	case c >= '\u0020' && c <= '\u007E':
+		return true // Printable ASCII
+	case c == '\u0085':
+		return true // Next Line (NEL)
+	case c >= '\u00A0' && c <= '\uD7FF':
+		return true // Basic Multilingual Plane (BMP)
+	case c >= '\uE000' && c <= '\uFFFD':
+		return true // Additional Unicode Areas
+	case c >= '\U00010000' && c <= '\U0010FFFF':
+		return true // 32 bit
+	default:
+		return false
+	}
+}
+
+func validateJSONKey(key string) error {
+	if len(key) > maxJSONKeyLen {
+		return fmt.Errorf("the key '%s' is too long for JSON", key)
+	}
+	for _, c := range key {
+		if !isValidJSONChar(c) {
+			return fmt.Errorf("invalid JSON character: '%c'", c)
+		}
+	}
+	return nil
+}
+
+func isValidJSONChar(c rune) bool {
+	// Checks whether a character is in the JSON valid character set as
+	// defined here: https://www.json.org/json-en.html
+	// This document specifies that any characters are valid except:
+	//   - Control characters (0x00-0x1F and 0x7f [DEL])
+	//   - Double quote (")
+	//   - Backslash (\)
+	switch {
+	case c >= '\u0000' && c <= '\u001F':
+		return false // Control characters other than DEL
+	case c == '\u007F':
+		return false // DEL
+	case c == rune('"'):
+		return false // Double quote
+	case c == rune('\\'):
+		return false // Backslash
+	default:
+		return true
+	}
+}
+
+func validateBashVarName(name string) error {
+	r := regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+	if !r.MatchString(name) {
+		explanation := "Must be alphanumerics and underscores, with first char being a non-digit"
+		return fmt.Errorf("invalid alias '%s': %s", name, explanation)
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds logic to validate the secrets aliases (based on output file format, e.g. YAML, JSON, Bash, or dotenv) and to validate the IDs (i.e. Conjur variable paths) contained in each `SecretSpec`.

The validation is done according to the
[Input Validations for Annotations](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/design/m1_push_to_file_design.md#input-validation-for-annotations)
section of the
[M1 Push-to-File Design Spec](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/design/m1_push_to_file_design.md).

The validation is done ***before*** retrieving any secret values from Conjur so that we fail fast.

### What ticket does this PR close?
ONYX-12559

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation