### PR TITLE
Update to Go 1.16 for Docker base images to fix CI build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # =================== BASE BUILD LAYER ===================
 # this layer is used to prepare a common layer for both debug and release builds
-FROM golang:1.15 as secrets-provider-builder-base
+FROM golang:1.16 as secrets-provider-builder-base
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-junit-processor"
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-test-runner"
 


### PR DESCRIPTION
### Desired Outcome

Jenkins builds of Docker images do NOT fail with errors such as the following:

```
[2021-10-26T21:50:18.036Z] #21 1.547 package embed: unrecognized import path "embed": import path does not begin with hostname
[2021-10-26T21:50:26.134Z] #21 8.793 package io/fs: unrecognized import path "io/fs": import path does not begin with hostname
[2021-10-26T21:50:32.671Z] #21 ERROR: executor failed running [/bin/sh -c go get -u github.com/jstemmer/go-junit-report &&     go get github.com/smartystreets/goconvey]: exit code: 1
```

### Implemented Changes

The version of Go used in our base Docker builder container is upgraded from Go v1.15 to Go v1.16.
This seems to eliminate the errors shown above.

### Connected Issue/Story

### Definition of Done

- Jenkins builds run with no errors.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
