### PR TITLE
Update secret group filepath behavior

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -20,7 +20,7 @@ import (
 const (
 	defaultContainerMode = "init"
 	annotationsFilePath  = "/conjur/podinfo/annotations"
-	secretBasePath       = "/conjur/secrets"
+	secretsBasePath      = "/conjur/secrets"
 )
 
 var annotationsMap map[string]string
@@ -69,6 +69,7 @@ func main() {
 		secretsConfig.StoreType,
 		secretsConfig.PodNamespace,
 		secretsConfig.RequiredK8sSecrets,
+		secretsBasePath,
 		annotationsMap,
 	)
 	logErrorsAndConditionalExit(errs, nil, messages.CSPFK053E)

--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -27,6 +27,7 @@ func NewProviderForType(
 	storeType string,
 	podNamespace string,
 	requiredK8sSecrets []string,
+	secretsBasePath string,
 	annotations map[string]string,
 ) (ProviderFunc, []error) {
 	switch storeType {
@@ -42,6 +43,7 @@ func NewProviderForType(
 	case config.File:
 		provider, err := pushtofile.NewProvider(
 			secretsRetrieverFunc,
+			secretsBasePath,
 			annotations,
 		)
 		if err != nil {

--- a/pkg/secrets/pushtofile/provide_conjur_secrets.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets.go
@@ -12,8 +12,8 @@ type fileProvider struct {
 }
 
 // NewProvider creates a new provider for Push-to-File mode.
-func NewProvider(retrieveSecretsFunc conjur.RetrieveSecretsFunc, annotations map[string]string) (*fileProvider, []error) {
-	secretGroups, err := NewSecretGroups(annotations)
+func NewProvider(retrieveSecretsFunc conjur.RetrieveSecretsFunc, secretsBasePath string, annotations map[string]string) (*fileProvider, []error) {
+	secretGroups, err := NewSecretGroups(secretsBasePath, annotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
@@ -20,12 +20,14 @@ func TestNewProvider(t *testing.T) {
 	TestCases := []struct {
 		description         string
 		retrieveFunc        conjur.RetrieveSecretsFunc
+		basePath            string
 		annotations         map[string]string
 		expectedSecretGroup []*SecretGroup
 	}{
 		{
 			description:  "happy case",
 			retrieveFunc: retrieve,
+			basePath:     "/basepath",
 			annotations: map[string]string{
 				"conjur.org/conjur-secrets.groupname":     "- password: path1\n",
 				"conjur.org/secret-file-path.groupname":   "path/to/file",
@@ -34,7 +36,7 @@ func TestNewProvider(t *testing.T) {
 			expectedSecretGroup: []*SecretGroup{
 				{
 					Name:            "groupname",
-					FilePath:        "path/to/file",
+					FilePath:        "/basepath/path/to/file",
 					FileTemplate:    "",
 					FileFormat:      "yaml",
 					FilePermissions: defaultFilePermissions,
@@ -51,7 +53,7 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tc := range TestCases {
 		t.Run(tc.description, func(t *testing.T) {
-			p, err := NewProvider(tc.retrieveFunc, tc.annotations)
+			p, err := NewProvider(tc.retrieveFunc, tc.basePath, tc.annotations)
 			assert.Empty(t, err)
 			assert.Equal(t, tc.expectedSecretGroup, p.secretGroups)
 		})
@@ -71,7 +73,7 @@ func TestProvideWithDeps(t *testing.T) {
 				secretGroups: []*SecretGroup{
 					{
 						Name:            "groupname",
-						FilePath:        "path/to/file",
+						FilePath:        "/path/to/file",
 						FileFormat:      "yaml",
 						FilePermissions: 123,
 						SecretSpecs: []SecretSpec{


### PR DESCRIPTION
### Desired Outcome

Previously, SP in Push to File mode required the full, absolute path of secret files, ie. `/conjur/secrets/path/file.yaml`, as opposed to requiring a relative path from `/conjur/secrets` as the design spec specifies. This PR updates P2F to fail when given absolute filepaths and succeed for relative filepaths.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
