### PR TITLE
Bump version to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.6] - 2021-10-29
+
 ### Added
+- Adds support for Secrets Provider M1 Push-to-File feature, Community release.
+  [cyberark/secrets-provider-for-k8s#358](https://github.com/cyberark/secrets-provider-for-k8s/pull/358)
+  [cyberark/secrets-provider-for-k8s#359](https://github.com/cyberark/secrets-provider-for-k8s/pull/359)
+  [cyberark/secrets-provider-for-k8s#362](https://github.com/cyberark/secrets-provider-for-k8s/pull/362)
+  [cyberark/secrets-provider-for-k8s#363](https://github.com/cyberark/secrets-provider-for-k8s/pull/363)
+  [cyberark/secrets-provider-for-k8s#364](https://github.com/cyberark/secrets-provider-for-k8s/pull/364)
+  [cyberark/secrets-provider-for-k8s#366](https://github.com/cyberark/secrets-provider-for-k8s/pull/366)
+  [cyberark/secrets-provider-for-k8s#367](https://github.com/cyberark/secrets-provider-for-k8s/pull/367)
+  [cyberark/secrets-provider-for-k8s#368](https://github.com/cyberark/secrets-provider-for-k8s/pull/368)
+  [cyberark/secrets-provider-for-k8s#376](https://github.com/cyberark/secrets-provider-for-k8s/pull/376)
+  [cyberark/secrets-provider-for-k8s#377](https://github.com/cyberark/secrets-provider-for-k8s/pull/377)
+  [cyberark/secrets-provider-for-k8s#378](https://github.com/cyberark/secrets-provider-for-k8s/pull/378)
 - Support for OpenShift 4.8 has been added.
+  [cyberark/secrets-provider-for-k8s#360](https://github.com/cyberark/secrets-provider-for-k8s/pull/360)
 
 ## [1.1.5] - 2021-08-13
 
@@ -131,7 +146,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.5...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.6...HEAD
+[1.1.6]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.2...v1.1.3

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.5'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.6'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.1.5
+version: 1.1.6
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.1.5
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.1.6
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.1.5
+  tag: 1.1.6
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.1.5"
+var Version = "1.1.6"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Version gets bumped from v1.1.5 to v1.1.6

### Implemented Changes

Version bumped to v1.1.6.

### Connected Issue/Story

Resolves #

CyberArk internal issue link: [ONYX-11205](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-11205)

### Definition of Done
- Everything done from: https://github.com/cyberark/secrets-provider-for-k8s/blob/main/CONTRIBUTING.md#update-the-version-changelog-and-notices

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
