### PR TITLE
Review unit testing for templated secret file output

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	err = provideSecrets()
 	if err != nil {
-		printErrorAndExit(fmt.Sprintf(messages.CSPFK039E, secretsConfig.StoreType))
+		printErrorAndExit(fmt.Sprintf(messages.CSPFK039E, secretsConfig.StoreType, err.Error()))
 	}
 }
 

--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -55,7 +55,7 @@ const CSPFK037E string = "CSPFK037E Failed to parse DAP/Conjur variable IDs"
 
 // General
 const CSPFK038E string = "CSPFK038E Retransmission backoff exhausted"
-const CSPFK039E string = "CSPFK039E Secrets Provider for Kubernetes failed to update secrets in %s mode"
+const CSPFK039E string = "CSPFK039E Secrets Provider for Kubernetes failed to update secrets in %s mode. Reason: %s"
 
 // Annotations
 const CSPFK040E string = "CSPFK040E Failed to parse annotations file"

--- a/pkg/secrets/pushtofile/push_to_writer_test.go
+++ b/pkg/secrets/pushtofile/push_to_writer_test.go
@@ -11,7 +11,7 @@ type pushToWriterTestCase struct {
 	description string
 	template    string
 	secrets     []*Secret
-	assert      func (*testing.T, string, error)
+	assert      func(*testing.T, string, error)
 }
 
 func (tc pushToWriterTestCase) Run(t *testing.T) {
@@ -27,7 +27,7 @@ func (tc pushToWriterTestCase) Run(t *testing.T) {
 	})
 }
 
-func assertGoodOutput(expected string) func (*testing.T, string, error) {
+func assertGoodOutput(expected string) func(*testing.T, string, error) {
 	return func(t *testing.T, actual string, err error) {
 		if !assert.NoError(t, err) {
 			return
@@ -44,18 +44,82 @@ func assertGoodOutput(expected string) func (*testing.T, string, error) {
 var writeToFileTestCases = []pushToWriterTestCase{
 	{
 		description: "happy path",
-		template: `{{secret "alias"}}`,
-		secrets: []*Secret{{Alias: "alias", Value: "secret value"}},
-		assert:  assertGoodOutput("secret value"),
+		template:    `{{secret "alias"}}`,
+		secrets:     []*Secret{{Alias: "alias", Value: "secret value"}},
+		assert:      assertGoodOutput("secret value"),
 	},
 	{
 		description: "undefined secret",
-		template: `{{secret "x"}}`,
-		secrets: []*Secret{{Alias: "some alias", Value: "secret value"}},
+		template:    `{{secret "x"}}`,
+		secrets:     []*Secret{{Alias: "some alias", Value: "secret value"}},
 		assert: func(t *testing.T, s string, err error) {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), `secret alias "x" not present in specified secrets for group`)
 		},
+	},
+	{
+		// Conversions defined in Go source:
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/text/template/funcs.go;l=608
+		description: "confirm use of built-in html escape template function",
+		template:    `{{secret "alias" | html}}`,
+		secrets:     []*Secret{{Alias: "alias", Value: "\" ' & < > \000"}},
+		assert:      assertGoodOutput("&#34; &#39; &amp; &lt; &gt; \uFFFD"),
+	},
+	{
+		description: "iterate over secret key-value pairs",
+		template: `{{- range $index, $secret := .SecretsArray -}}
+{{- if $index }}
+{{ end }}
+{{- $secret.Alias }}: {{ $secret.Value }}
+{{- end -}}`,
+		secrets: []*Secret{
+			{Alias: "environment", Value: "prod"},
+			{Alias: "url", Value: "https://example.com"},
+			{Alias: "username", Value: "example-user"},
+			{Alias: "password", Value: "example-pass"},
+		},
+		assert: assertGoodOutput(`environment: prod
+url: https://example.com
+username: example-user
+password: example-pass`),
+	},
+	{
+		description: "nested templates",
+		template: `{{- define "contents" -}}
+Alias : {{ .Alias }}
+Value : {{ .Value }}
+{{ end }}
+{{- define "parent" -}}
+Nested Template
+{{ template "contents" . -}}
+===============
+{{ end }}
+{{- range $index, $secret := .SecretsArray -}}
+{{ template "parent" . }}
+{{- end -}}`,
+		secrets: []*Secret{
+			{Alias: "environment", Value: "prod"},
+			{Alias: "url", Value: "https://example.com"},
+			{Alias: "username", Value: "example-user"},
+			{Alias: "password", Value: "example-pass"},
+		},
+		assert: assertGoodOutput(`Nested Template
+Alias : environment
+Value : prod
+===============
+Nested Template
+Alias : url
+Value : https://example.com
+===============
+Nested Template
+Alias : username
+Value : example-user
+===============
+Nested Template
+Alias : password
+Value : example-pass
+===============
+`),
 	},
 }
 
@@ -64,4 +128,3 @@ func Test_pushToWriter(t *testing.T) {
 		tc.Run(t)
 	}
 }
-

--- a/pkg/secrets/pushtofile/secret_group.go
+++ b/pkg/secrets/pushtofile/secret_group.go
@@ -89,7 +89,7 @@ func (sg *SecretGroup) pushToFileWithDeps(
 	defer func() {
 		_ = wc.Close()
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic recovered while pushing to writer")
+			err = fmt.Errorf("panic recovered while executing template with secret values")
 		}
 	}()
 

--- a/pkg/secrets/pushtofile/secret_group.go
+++ b/pkg/secrets/pushtofile/secret_group.go
@@ -316,11 +316,7 @@ func newSecretGroup(groupName string, secretsBasePath string, annotations map[st
 
 	secretSpecs, err := NewSecretSpecs([]byte(groupSecrets))
 	if err != nil {
-		err = fmt.Errorf(
-			`cannot create secret specs from annotation "%s": %s`,
-			secretGroupPrefix+groupName,
-			err,
-		)
+		err = fmt.Errorf(`cannot create secret specs from annotation "%s": %s`, secretGroupPrefix+groupName, err)
 		return nil, []error{err}
 	}
 

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -554,7 +554,7 @@ var pushToFileWithDepsTestCases = []pushToFileWithDepsTestCase{
 			if !assert.Error(t, err) {
 				return
 			}
-			assert.Contains(t, err.Error(), "panic recovered while pushing to writer")
+			assert.Contains(t, err.Error(), "panic recovered while executing template with secret values")
 			assert.NotContains(t, err.Error(), "canned panic response - maybe containing secrets")
 		},
 	},


### PR DESCRIPTION
### Desired Outcome

Review the design doc and confirm that we have sufficient test coverage for the template file output feature.

From the design doc:
| Given | Then |
|-|-|
| "secret-file-template" annotation referencing secrets by name (alias) | The internal representation matches expectation |
| "secret-file-template" annotation iterative over all secrets | The internal representation matches expectation |
| "secret-file-template" annotation using built-in template function (e.g. `html`) | The internal representation matches expectation |
| "secret-file-template" annotation using custom functions with nested templates | The internal representation matches expectations |

### Implemented Changes

The following were already tested:
- template referencing secrets by name (alias)

Adds unit testing for the following cases:
- iterative custom template
- use of built-in template funcs (html)
- nested templates

Includes implementing a "double-pass" method for template rendering.
Now, a malformed template will cause SP to fail fast, before fetching secrets.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-13144]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
