### PR TITLE
Add unit test cases for SP with mixed-source config

### DIFF
--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -209,6 +209,17 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 		assert: assertEmptyErrorList(),
 	},
 	{
+		description: "mixed-source config",
+		envAndAnnots: map[string]string{
+			"MY_POD_NAMESPACE":               "test-namespace",
+			"conjur.org/secrets-destination": "k8s_secrets",
+			"RETRY_COUNT_LIMIT":              "10",
+			"conjur.org/retry-interval-sec":  "20",
+			"K8S_SECRETS":                    "secret-1,secret-2,secret-3",
+		},
+		assert: assertEmptyErrorList(),
+	},
+	{
 		description: "if StoreType is configured with both its annotation and envVar, an info-level error is returned",
 		envAndAnnots: map[string]string{
 			"MY_POD_NAMESPACE":               "test-namespace",
@@ -357,6 +368,23 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{},
 			RetryCountLimit:    DefaultRetryCountLimit,
 			RetryIntervalSec:   DefaultRetryIntervalSec,
+		}),
+	},
+	{
+		description: "mixed-source config",
+		settings: map[string]string{
+			"MY_POD_NAMESPACE":               "test-namespace",
+			"conjur.org/secrets-destination": "k8s_secrets",
+			"RETRY_COUNT_LIMIT":              "10",
+			"conjur.org/retry-interval-sec":  "20",
+			"K8S_SECRETS":                    "secret-1,secret-2,secret-3",
+		},
+		assert: assertGoodConfig(&Config{
+			PodNamespace:       "test-namespace",
+			StoreType:          "k8s_secrets",
+			RequiredK8sSecrets: []string{"secret-1", "secret-2", "secret-3"},
+			RetryCountLimit:    10,
+			RetryIntervalSec:   20,
 		}),
 	},
 }


### PR DESCRIPTION
### Desired Outcome

Previously, unit tests confirmed the following:
- SP can be configured with environment variables
- SP can be configured with annotations
- if SP is provided complete sets of both envvars and annotations, config is successful

This PR adds unit test cases to confirm that SP can be successfully configured when provided envvars and annotations that satisfy all required config fields, but do not overlap.

### Implemented Changes

Adds a test case to the following test case slices, each confirming successful operation when provided envvars and annotations do not overlap.
- `validateSecretsProviderSettingsTestCases`
- `newConfigTestCases`

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-13146](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13146)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
