### PR TITLE
Add P2F docs for using custom templates

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -140,6 +140,9 @@ tags = ["key", "Mailgun"]
 description = "Password in URL"
 regex = '''[a-zA-Z]{3,10}:\/\/[^\/\s:@]{3,20}:[^\/\s:@]{3,20}@.{1,100}\/?.?'''
 tags = ["key", "URL", "generic"]
+[rules.allowlist]
+description = "Push to File documentation for custom templates include sample postgres connection string"
+files = ["PUSH_TO_FILE.md"]
 
 [[rules]]
 description = "PayPal Braintree access token"


### PR DESCRIPTION
Depends on #390 

### Desired Outcome

From [ONYX-14031](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14031):
- Overview of how custom templates work and how to reference secrets
- Example custom template
- Description of notable template functions for this use of Golang, with link to external Golang template docs for full details.
- Include note that the initial validation uses fake data to provide early and secure feedback with complete messages, so templates that rely on secret values (i.e. sprintf to format a number) may fail at this stage. But they still would work fine with real secret data.

### Implemented Changes

Makes a few additions to `PUSH_TO_FILE.md`:
- an entry in the `Reference Table of Configuration Annotations` for `conjur.org/secret-file-template.{secret-group}`
- section `Custom Templates For Secret Files`, which includes
  - overview of custom templates
  - detail referencing secrets in custom templates
  - note of template functions in Go's `text/template` package
  - description of "double-pass" render procedure and a note suggesting against using templates that rely on secret values
  - example custom templates and outputs


### Connected Issue/Story

CyberArk internal issue link: [ONYX-14031](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14031)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
