### PR TITLE
Fix SecretGroup common policy path

### DIFF
--- a/PUSH_TO_FILE.md
+++ b/PUSH_TO_FILE.md
@@ -8,6 +8,7 @@
 - [Certification Level](#certification-level)
 - [Set up Secrets Provider for Push to File](#set-up-secrets-provider-for-push-to-file)
 - [Reference Table of Configuration Annotations](#reference-table-of-configuration-annotations)
+- [Example Common Policy Path](#example-common-policy-path)
 - [Example Secret File Formats](#example-secret-file-formats)
 - [Custom Templates for Secret Files](#custom-templates-for-secret-files)
 - [Secret File Attributes](#secret-file-attributes)
@@ -238,9 +239,10 @@ Push to File operation.
            conjur.org/authn-identity: host/conjur/authn-k8s/dev-cluster/test-app
            conjur.org/container-mode: init
            conjur.org/secret-destination: file
+           conjur.org/conjur-secrets-policy-path.first: secrets/
            conjur.org/conjur-secrets.test-app: |
-           - admin-username: secrets/username
-           - admin-password: secrets/password
+           - admin-username: username
+           - admin-password: password
            conjur.org/secret-file-path.test-app: "./credentials.yaml"
            conjur.org/secret-file-format.test-app: "yaml"
        spec:
@@ -303,6 +305,7 @@ for a description of each environment variable setting:
 | `conjur.org/retry-interval-sec`     | `RETRY_INTERVAL_SEC`  | Defaults to 1 (sec)              |
 | `conjur.org/debug-logging`          | `DEBUG`               | Defaults to `false`              |
 | `conjur.org/conjur-secrets.{secret-group}`      | Note\* | List of secrets to be retrieved from Conjur. Each entry can be either:<ul><li>A Conjur variable path</li><li> A key/value pairs of the form `<alias>:<Conjur variable path>` where the `alias` represents the name of the secret to be written to the secrets file |
+| `conjur.org/conjur-secrets-policy-path.{secret-group}` | Note\* | Defines a common Conjur policy path, assumed to be relative to the root policy.<br><br>When this annotation is set, the policy paths defined by `conjur.org/conjur-secrets.{secret-group}` are relative to this common path.<br><br>When this annotation is not set, the policy paths defined by `conjur.org/conjur-secrets.{secret-group}` are themselves relative to the root policy.<br><br>(See [Example Common Policy Path](#example-common-policy-path) for an explicit example of this relationship.)|
 | `conjur.org/secret-file-path.{secret-group}`    | Note\* | Relative path for secret file or directory to be written. This path is assumed to be relative to the respective mount path for the shared secrets volume for each container.<br><br>If the `conjur.org/secret-file-template.{secret-group}` is set, then this secret file path must also be set, and it must include a file name (i.e. must not end in `/`).<br><br>If the `conjur.org/secret-file-template.{secret-group}` is not set, then this secret file path defaults to `{secret-group}.{secret-group-file-format}`. For example, if the secret group name is `my-app`, and the secret file format is set for YAML, the the secret file path defaults to `my-app.yaml`.
 | `conjur.org/secret-file-format.{secret-group}`  | Note\* | Allowed values:<ul><li>yaml (default)</li><li>json</li><li>dotenv</li><li>bash</li></ul>(See [Example Secret File Formats](#example-secret-file-formats) for example output files.) |
 | `conjur.org/secret-file-template.{secret-group}`| Note\* | Defines a custom template in Golang text template format with which to render secret file content. See dedicated [Custom Templates for Secret Files](#custom-templates-for-secret-files) section for details. |
@@ -310,6 +313,27 @@ for a description of each environment variable setting:
 __Note*:__ These Push to File annotations do not have an equivalent
 environment variable setting. The Push to File feature must be configured
 using annotations.
+
+## Example Common Policy Path
+
+Given the relationship between `conjur.org/conjur-secrets.{secret-group}` and
+`conjur.org/conjur-secrets-policy-path.{secret-group}`, the following sets of
+annotations will eventually retrieve the same secrets from Conjur:
+
+```
+conjur.org/conjur-secrets.db: |
+  - url: policy/path/api-url
+  - policy/path/username
+  - policy/path/password
+```
+
+```
+conjur.org/conjur-secrets-policy-path.db: policy/path/
+conjur.org/conjur-secrets.db: |
+  - url: api-url
+  - username
+  - password
+```
 
 ## Example Secret File Formats
 

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -100,8 +100,9 @@ func goodSecretSpecs() []SecretSpec {
 func TestNewSecretGroups(t *testing.T) {
 	t.Run("valid annotations", func(t *testing.T) {
 		secretGroups, errs := NewSecretGroups("/basepath", map[string]string{
-			"conjur.org/conjur-secrets.first": `- path/to/secret/first1
-- aliasfirst2: path/to/secret/first2`,
+			"conjur.org/conjur-secrets-policy-path.first": "/path/to/secret/",
+			"conjur.org/conjur-secrets.first": `- first1
+- aliasfirst2: first2`,
 			"conjur.org/secret-file-path.first":      "firstfilepath",
 			"conjur.org/secret-file-template.first":  `firstfiletemplate`,
 			"conjur.org/conjur-secrets.second":       "- path/to/secret/second",
@@ -114,11 +115,12 @@ func TestNewSecretGroups(t *testing.T) {
 		}
 		assert.Len(t, secretGroups, 2)
 		assert.Equal(t, *secretGroups[0], SecretGroup{
-			Name:            "first",
-			FilePath:        "/basepath/firstfilepath",
-			FileTemplate:    "firstfiletemplate",
-			FileFormat:      "",
-			FilePermissions: defaultFilePermissions,
+			Name:             "first",
+			FilePath:         "/basepath/firstfilepath",
+			FileTemplate:     "firstfiletemplate",
+			FileFormat:       "",
+			FilePermissions:  defaultFilePermissions,
+			PolicyPathPrefix: "path/to/secret/",
 			SecretSpecs: []SecretSpec{
 				{
 					Alias: "first1",


### PR DESCRIPTION
### Desired Outcome

From ONYX-14902:
> We added the [secrets-policy-path](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/design/m1_push_to_file_design.md#supported-annotations) annotation but it does not appear to be working as intended.
> Write some unit tests to cover the functionality (mostly [here](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/pkg/secrets/pushtofile/secret_group.go)) and make sure the annotation is documented in PUSH_TO_FILE.md.

When the annotation `conjur.org/conjur-secrets-policy-path.{secret-group}` is set, it defines a common policy path prefix, assumed to be relative to the root policy. Policy paths defined in `conjur.org/conjur-secrets.{secret-group}` are relative to this common path.

When the annotation is not set, the policy paths defined in `conjur.org/conjur-secrets.{secret-group}` are themselves relative to the root policy.

### Implemented Changes

- The function `newSecretGroup` constructs a new `SecretGroup` `sg`, then makes a call to `sg.resolveSecretSpecs()`.
  - If a common policy path has been provided by with the annotation `conjur.org/conjur-secret-policy-path.{secret-group}`, then the `SecretSpecs` field is replaced by a copy of itself, with all secret paths being prepended with the common policy path.
  - If a common policy path has NOT been provided, then existing slice in field `SecretSpecs` is assumed to contain fully-qualified policy paths to Conjur secrets, and it not updated.
- Updated happy path test cases in `secret_group_test.go`
- `PUSH_TO_FILE.md` updated to describe `conjur.org/conjur-secret-policy-path.{secret-group}` annotation. Included an example to show two functionally identical annotation sets, one with a common policy prefix, and one without.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14092](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14092)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
