### PR TITLE
Allow P2F custom templates via ConfigMap

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -20,6 +20,7 @@ const (
 	defaultContainerMode = "init"
 	annotationsFilePath  = "/conjur/podinfo/annotations"
 	secretsBasePath      = "/conjur/secrets"
+	templatesBasePath    = "/conjur/templates"
 )
 
 var annotationsMap map[string]string
@@ -62,11 +63,12 @@ func main() {
 	}
 
 	providerConfig := secrets.ProviderConfig{
-		StoreType:          secretsConfig.StoreType,
-		PodNamespace:       secretsConfig.PodNamespace,
-		RequiredK8sSecrets: secretsConfig.RequiredK8sSecrets,
-		SecretFileBasePath: secretsBasePath,
-		AnnotationsMap:     annotationsMap,
+		StoreType:            secretsConfig.StoreType,
+		PodNamespace:         secretsConfig.PodNamespace,
+		RequiredK8sSecrets:   secretsConfig.RequiredK8sSecrets,
+		SecretFileBasePath:   secretsBasePath,
+		TemplateFileBasePath: templatesBasePath,
+		AnnotationsMap:       annotationsMap,
 	}
 	provideSecrets, errs := secrets.NewProviderForType(
 		secretRetriever.Retrieve,

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -65,7 +65,7 @@ var pushToFileAnnotationPrefixes = map[string]annotationRestraints{
 	"conjur.org/conjur-secrets.":             {TYPESTRING, []string{}},
 	"conjur.org/conjur-secrets-policy-path.": {TYPESTRING, []string{}},
 	"conjur.org/secret-file-path.":           {TYPESTRING, []string{}},
-	"conjur.org/secret-file-format.":         {TYPESTRING, []string{"yaml", "json", "dotenv", "bash"}},
+	"conjur.org/secret-file-format.":         {TYPESTRING, []string{"yaml", "json", "dotenv", "bash", "template"}},
 	"conjur.org/secret-file-template":        {TYPESTRING, []string{}},
 }
 

--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -26,8 +26,9 @@ type ProviderConfig struct {
 	RequiredK8sSecrets []string
 
 	// Config specific to Push to File provider
-	SecretFileBasePath string
-	AnnotationsMap     map[string]string
+	SecretFileBasePath   string
+	TemplateFileBasePath string
+	AnnotationsMap       map[string]string
 }
 
 // ProviderFunc describes a function type responsible for providing secrets to an unspecified target.
@@ -50,6 +51,7 @@ func NewProviderForType(
 		provider, err := pushtofile.NewProvider(
 			secretsRetrieverFunc,
 			providerConfig.SecretFileBasePath,
+			providerConfig.TemplateFileBasePath,
 			providerConfig.AnnotationsMap,
 		)
 		if err != nil {

--- a/pkg/secrets/pushtofile/provide_conjur_secrets.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets.go
@@ -12,8 +12,8 @@ type fileProvider struct {
 }
 
 // NewProvider creates a new provider for Push-to-File mode.
-func NewProvider(retrieveSecretsFunc conjur.RetrieveSecretsFunc, secretsBasePath string, annotations map[string]string) (*fileProvider, []error) {
-	secretGroups, err := NewSecretGroups(secretsBasePath, annotations)
+func NewProvider(retrieveSecretsFunc conjur.RetrieveSecretsFunc, secretsBasePath string, templatesBasePath string, annotations map[string]string) (*fileProvider, []error) {
+	secretGroups, err := NewSecretGroups(secretsBasePath, templatesBasePath, annotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
@@ -53,7 +53,7 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tc := range TestCases {
 		t.Run(tc.description, func(t *testing.T) {
-			p, err := NewProvider(tc.retrieveFunc, tc.basePath, tc.annotations)
+			p, err := NewProvider(tc.retrieveFunc, tc.basePath, "", tc.annotations)
 			assert.Empty(t, err)
 			assert.Equal(t, tc.expectedSecretGroup, p.secretGroups)
 		})

--- a/pkg/secrets/pushtofile/pull_from_reader.go
+++ b/pkg/secrets/pushtofile/pull_from_reader.go
@@ -1,0 +1,33 @@
+package pushtofile
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type pullFromReaderFunc func(
+	reader io.Reader,
+) (string, error)
+
+type openReadCloserFunc func(
+	path string,
+) (io.ReadCloser, error)
+
+func openFileAsReadCloser(path string) (io.ReadCloser, error) {
+	reader, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.NopCloser(reader), nil
+}
+
+func pullFromReader(
+	reader io.Reader,
+) (string, error) {
+	content, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}

--- a/pkg/secrets/pushtofile/pull_from_reader_test.go
+++ b/pkg/secrets/pushtofile/pull_from_reader_test.go
@@ -1,0 +1,34 @@
+package pushtofile
+
+import (
+	"bytes"
+	"testing"
+)
+
+type pullFromReaderTestCase struct {
+	description string
+	content     string
+	assert      func(*testing.T, string, error)
+}
+
+func (tc pullFromReaderTestCase) Run(t *testing.T) {
+	t.Run(tc.description, func(t *testing.T) {
+		buf := bytes.NewBufferString(tc.content)
+		readContent, err := pullFromReader(buf)
+		tc.assert(t, readContent, err)
+	})
+}
+
+var pullFromReaderTestCases = []pullFromReaderTestCase{
+	{
+		description: "happy case",
+		content:     "template file content",
+		assert:      assertGoodOutput("template file content"),
+	},
+}
+
+func TestPullFromReader(t *testing.T) {
+	for _, tc := range pullFromReaderTestCases {
+		tc.Run(t)
+	}
+}

--- a/pkg/secrets/pushtofile/secret-group_utils_test.go
+++ b/pkg/secrets/pushtofile/secret-group_utils_test.go
@@ -3,6 +3,7 @@ package pushtofile
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 )
 
@@ -75,4 +76,62 @@ func (spy *openWriteCloserSpy) Call(path string, permissions os.FileMode) (io.Wr
 	}
 
 	return spy.writeCloser, spy.err
+}
+
+//// pullFromReaderFunc
+type pullFromReaderArgs struct {
+	reader io.Reader
+}
+
+type pullFromReaderSpy struct {
+	args   pullFromReaderArgs
+	err    error
+	_calls int
+}
+
+func (spy *pullFromReaderSpy) Call(
+	reader io.Reader,
+) (string, error) {
+	spy._calls++
+	// This is to ensure the spy is only ever used once!
+	if spy._calls > 1 {
+		panic("spy called more than once")
+	}
+
+	spy.args = pullFromReaderArgs{
+		reader: reader,
+	}
+
+	content, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return string(content), err
+	}
+
+	return string(content), spy.err
+}
+
+//// openReadCloserFunc
+type openReadCloserArgs struct {
+	path string
+}
+
+type openReadCloserSpy struct {
+	args       openReadCloserArgs
+	readCloser io.ReadCloser
+	err        error
+	_calls     int
+}
+
+func (spy *openReadCloserSpy) Call(path string) (io.ReadCloser, error) {
+	spy._calls++
+	// This is to ensure the spy is only ever used once!
+	if spy._calls > 1 {
+		panic("spy called more than once")
+	}
+
+	spy.args = openReadCloserArgs{
+		path: path,
+	}
+
+	return spy.readCloser, spy.err
 }

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -416,11 +416,18 @@ func TestNewSecretGroups(t *testing.T) {
 			err:        nil,
 		}
 
-		groups, errs := newSecretGroupsWithDeps("/basepath", "/templates", map[string]string{
+		config := Config{
+			secretsBasePath:   "/basepath",
+			templatesBasePath: "/templates",
+			openReadCloser:    spyOpenReadCloser.Call,
+			pullFromReader:    spyPullFromReader.Call,
+		}
+
+		groups, errs := newSecretGroupsWithDeps(map[string]string{
 			"conjur.org/conjur-secrets.first":     "- path/to/secret/first1\n",
 			"conjur.org/secret-file-format.first": "template",
 			"conjur.org/secret-file-path.first":   "firstfilepath",
-		}, readFileFuncs{openReadCloser: spyOpenReadCloser.Call, pullFromReader: spyPullFromReader.Call})
+		}, config)
 
 		assert.Empty(t, errs)
 		assert.Equal(t, *groups[0], SecretGroup{
@@ -448,12 +455,19 @@ func TestNewSecretGroups(t *testing.T) {
 			err:        nil,
 		}
 
-		_, errs := newSecretGroupsWithDeps("/basepath", "/templates", map[string]string{
+		config := Config{
+			secretsBasePath:   "/basepath",
+			templatesBasePath: "/templates",
+			openReadCloser:    spyOpenReadCloser.Call,
+			pullFromReader:    spyPullFromReader.Call,
+		}
+
+		_, errs := newSecretGroupsWithDeps(map[string]string{
 			"conjur.org/conjur-secrets.first":       "- path/to/secret/first1\n",
 			"conjur.org/secret-file-path.first":     "firstfilepath",
 			"conjur.org/secret-file-format.first":   "template",
 			"conjur.org/secret-file-template.first": "annotation-template",
-		}, readFileFuncs{openReadCloser: spyOpenReadCloser.Call, pullFromReader: spyPullFromReader.Call})
+		}, config)
 
 		assert.NotEmpty(t, errs)
 		assert.Contains(t, errs[0].Error(), "cannot be provided both by annotation and by ConfigMap")


### PR DESCRIPTION
### Desired Outcome

From [ONYX-14093](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14093):

> Currently custom templates must be provided through the `conjur.org/secret-file-template.{secret-group}` annotation. We would also like to be able to provide a template through a configmap such that the configmap is mounted as a volume and secrets-provider reads the template as a file from the file system.
>
>The template file should be mounted to a hard-coded path, and must use the file name `{secret-group}.tpl`. Add documentation to `PUSH_TO_FILE.md` that describes this path.
>
>Secrets Provider must be told to look for a mounted ConfigMap template. There are a couple of options here:
> - adding a new annotation which indicates that a secret group is used a template mounted from a ConfigMap
> - adding a new "template" file format enum for the conjur.org/secret-file-format.{secret-group} annotation
Providing both the template filepath and annotation should result in a fatal error.

### Implemented Changes

#### Behavioral Changes
If a secret group's output file format, specified with the annotation `conjur.org/secret-file-format.{secret-group}`, is set to `template`, then the function `newSecretGroup` will look for either an annotation- or ConfigMap-based template string.

The ConfigMap defining templates must be mounted to `/conjur/templates`, and the key for a given template value must be `{secret-group}.tpl`. At secret group creation, Secrets Provider will only attempt to read from this file. If the file does not exist, it is assumed that a template was not provided via ConfigMap.

If the annotation `conjur.org/secret-file-format.{secret-group}` is set to `template`, and templates are provided through BOTH the group's annotation and volume-mounted ConfigMap, secret group creation will receive a failing error.

If the annotation `conjur.org/secret-file-format.{secret-group}` is not set to `template`, Secrets Provider will never look for a template in either form. If a template is provided by either/both method(s), it will be ignored.

#### Explicit Changes
- Added `template` to `conjur.org/secret-file-format.{secret-group}` accepted values
- Added `pkg/secrets/pushtofile/pull_from_reader.go`, a counterpart to `push_to_writer.go`, to mock and dependency-inject reading content from the filesystem.
- In `secret_group.go`:
  - Separated `func NewSecretGroups` into itself and `func newSecretGroupsWithDeps` to dep-inject file reading operations
  - Added new functions `collectTemplate` and `readTemplateFromFile`
- Updated unit tests to reflect the above changes
- `PUSH_TO_FILE.md` updates

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-14903](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14093)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
