### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-11-30
+
+### Added
+- Adds validation for output filepaths and names in Push-to-File, requiring
+  valid Linux filenames that are unique across all secret groups.
+  [cyberark/secrets-provider-for-k8s#386](https://github.com/cyberark/secrets-provider-for-k8s/pull/386)
+- Adds support for Push-to-File annotation `conjur.org/conjur-secrets-policy-path.{secret-group}`.
+  [cyberark/secrets-provider-for-k8s#392](https://github.com/cyberark/secrets-provider-for-k8s/pull/392)
+
+### Changed
+- Push-to-File supports more intuitive output filepaths. Filepaths are
+  no longer required to contain the hard-coded mount path `/conjur/secrets`, and
+  can specify intermediate directories.
+  [cyberark/secrets-provider-for-k8s#381](https://github.com/cyberark/secrets-provider-for-k8s/pull/381)
+
 ## [1.1.6] - 2021-10-29
 
 ### Added
@@ -146,7 +161,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.6...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.6...v1.2.0
 [1.1.6]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.3...v1.1.4

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -7,11 +7,12 @@ of the license associated with each component.
 
 
 Section 1: Apache-2.0
->>> github.com/cyberark/conjur-api-go - v0.6.0
->>> github.com/cyberark/conjur-authn-k8s-client - v0.19.1
+>>> github.com/cyberark/conjur-api-go - v0.8.0
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.22.1-0.20211013211359-5ca23711965d
 >>> github.com/googleapis/gnostic - v0.3.1
 >>> github.com/modern-go/reflect2 - v1.0.1
 >>> gopkg.in/yaml.v2 - v2.3.0
+>>> gopkg.in/yaml.v3 - v3.0.0-20210107192922-496545a6307b
 >>> k8s.io/api - v0.0.0-20190313235455-40a48860b5ab
 >>> k8s.io/apimachinery - v0.0.0-20190313205120-d7deff9243b1
 >>> k8s.io/client-go - v11.0.0
@@ -20,6 +21,8 @@ Section 1: Apache-2.0
 
 Section 2: BSD 3-Clause
 >>> github.com/gogo/protobuf  - v1.3.2
+>>> github.com/golang/protobuf - v1.4.2
+>>> github.com/spf13/pflag - v1.0.5
 >>> golang.org/x/oauth2 - v0.0.0-20191202225959-858c2ad4c8b6
 >>> golang.org/x/time - v0.0.0-20191024005414-555d28b269f0
 >>> gopkg.in/inf.v0 - v0.9.1
@@ -28,7 +31,9 @@ Section 2: BSD 3-Clause
 Section 3: MIT
 >>> github.com/cenkalti/backoff - v2.2.1
 >>> github.com/json-iterator/go - v1.1.9
->>> github.com/smartystreets/goconvey - v0.0.0-20190731233626-505e41936337
+>>> github.com/smartystreets/goconvey - v1.6.4
+>>> github.com/stretchr/testify - v1.7.0
+>>> gopkg.in/yaml.v3 - v3.0.0-20210107192922-496545a6307b
 >>> sigs.k8s.io/yaml - v1.1.0
 
 
@@ -42,7 +47,7 @@ APPENDIX: Standard License Files and Templates
 
 Apache-2.0 License is applicable to the following component(s).
 
->>> github.com/cyberark/conjur-api-go - v0.6.0
+>>> github.com/cyberark/conjur-api-go - v0.8.0
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
@@ -58,7 +63,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/cyberark/conjur-authn-k8s-client - v0.19.1
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.22.1-0.20211013211359-5ca23711965d
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
@@ -107,6 +112,22 @@ limitations under the License.
 >>> gopkg.in/yaml.v2 - v2.3.0
 
 Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>>> gopkg.in/yaml.v3 - v3.0.0-20210107192922-496545a6307b
+
+Copyright (c) 2011-2019 Canonical Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -227,6 +248,67 @@ copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
     * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> github.com/golang/protobuf - v1.4.2
+
+Copyright 2010 The Go Authors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> github.com/spf13/pflag - v1.0.5
+
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
@@ -412,7 +494,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
->>> github.com/smartystreets/goconvey - v0.0.0-20190731233626-505e41936337
+>>> github.com/smartystreets/goconvey - v1.6.4
 
 Copyright (c) 2016 SmartyStreets, LLC
 
@@ -436,6 +518,58 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 NOTE: Various optional and subordinate components carry their own licensing
 requirements and restrictions. Use of those components is subject to the terms and
 conditions outlined the respective license of each component.
+
+>>> github.com/stretchr/testify - v1.7.0
+
+Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+>>> gopkg.in/yaml.v3 - v3.0.0-20210107192922-496545a6307b
+
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original MIT license, with the additional
+copyright staring in 2011 when the project was ported over:
+
+    apic.go emitterc.go parserc.go readerc.go scannerc.go
+    writerc.go yamlh.go yamlprivateh.go
+
+Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2006-2011 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 >>> sigs.k8s.io/yaml - v1.1.0
 

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.1.6'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.2.0'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.1.6
+version: 1.2.0
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.1.6
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.2.0
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.1.6
+  tag: 1.2.0
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.1.6"
+var Version = "1.2.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Release Secrets Provider for PAS 12.4

### Implemented Changes

- Updated `CHANGELOG.md` to represent latest user-facing changes
- Updated `NOTICES.txt` to include latest packages added to `go.mod`
- Updated hardcoded version from `1.1.6` to `1.2.0` for
  - Version file @ `pkg/secrets/version.go`
  - Chart version @ `helm/secrets-provider/Chart.yaml`
  - Default deployed version @ `helm/secrets-provider/values.yaml`
  - Helm unit test for chart defaults @ `helm/secrets-provider/tests/secrets_provider_test.yaml`
  - Test case hardcoded version @`deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh`

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14382](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14382)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
