### PR TITLE
Build and push images on version tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
         // Run tests only when EITHER of the following is true:
         // 1. A non-markdown file has changed.
         // 2. It's the main branch.
+        // 3. It's a version tag, typically created during a release
         anyOf {
           // Note: You cannot use "when"'s changeset condition here because it's
           // not powerful enough to express "_only_ md files have changed".
@@ -50,6 +51,9 @@ pipeline {
 
           // Always run the full pipeline on main branch
           branch 'main'
+
+          // Always run the full pipeline on a version tag created during release
+          tag "v*"
         }
       }
       stages {


### PR DESCRIPTION
The Jenkinsfile includes a when conditional intended to prevent the pipeline
from building and releasing when only markdown files have been changed. It
unfortunately also prevents a build and release when a version tag has been
created since no files are changed from the main branch. We fix this by also
requiring build and release on tags with a naming scheme of v*.
