### PR TITLE
Push to File should not error out if file already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- If the Secrets Provider is run in Push-to-File mode, it no longer errors out
+  if it finds any pre-existing secret files. This is helpful when the Secrets
+  Provider is being run multiple times.
+  [cyberark/secrets-provider-for-k8s#397](https://github.com/cyberark/secrets-provider-for-k8s/pull/397)
+
 ## [1.2.0] - 2021-11-30
 
 ### Added

--- a/pkg/secrets/pushtofile/push_to_writer.go
+++ b/pkg/secrets/pushtofile/push_to_writer.go
@@ -39,7 +39,7 @@ func openFileAsWriteCloser(path string, permissions os.FileMode) (io.WriteCloser
 		return nil, fmt.Errorf("unable to mkdir when opening file to write at %q: %s", path, err)
 	}
 
-	wc, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, permissions)
+	wc, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, permissions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open file to write at %q: %s", path, err)
 	}

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -681,7 +681,7 @@ func TestSecretGroup_PushToFile(t *testing.T) {
 		// Create a group, and push to file
 		group := SecretGroup{
 			Name:            "groupname",
-			FilePath:        "/dev/stdout",
+			FilePath:        "/",
 			FileTemplate:    "",
 			FileFormat:      "yaml",
 			FilePermissions: 0744,


### PR DESCRIPTION
### Desired Outcome

Currently, when Secrets Provider is configured for Push-to-File mode, and a secret file is created in the shared secret volume, it errors out (exits) if that file already exists.

This current behavior is reasonable IF we're running the Secrets Provider as a "one and done" init container, whereby SP starts with an empty shared volume, and we would never expect a secrets file to already exist in that
volume.

However, future applications of Push-to-File will use the Secrets Provider as a Sidecar container, either running periodically, or running asynchronously upon receipt of an external signal (e.g. a webhook). In these cases, we need
the Secrets Provider to tolerate the pre-existence of the secret files.

Note that when processing Pod Annotations for Push-to-File feature (way before we try to actually create and write the secret files), we already test for duplication, i.e. we check that none of the secret groups are using identical destination file path. Because of this, checking for the existence of a secret file as we are creating the file is unnecessary.

### Implemented Changes

- SP in Push-to-File mode does not use the `os.O_EXCL` flag when creating a secret file.
- Also had to change a P2F UT test case since opening `/dev/stdout` was no longer resulting in a file open error
  after the `os.O_EXCL` flag was removed. This test case now tries to open `/`, which causes the desired error mode.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: ONYX-14473

### Definition of Done
- [x] `os.O_EXCL` flag removed from file open
- [x] CHANGELOG.md entry added

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
