### PR TITLE
Remove extra error message

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -44,7 +44,7 @@ func main() {
 	if _, err := os.Stat(annotationsFilePath); err == nil {
 		annotationsMap, err = annotations.NewAnnotationsFromFile(annotationsFilePath)
 		if err != nil {
-			printErrorAndExit(messages.CSPFK040E)
+			printErrorAndExit(err.Error())
 		}
 
 		errLogs, infoLogs := secretsConfigProvider.ValidateAnnotations(annotationsMap)

--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -58,7 +58,6 @@ const CSPFK038E string = "CSPFK038E Retransmission backoff exhausted"
 const CSPFK039E string = "CSPFK039E Secrets Provider for Kubernetes failed to update secrets in %s mode. Reason: %s"
 
 // Annotations
-const CSPFK040E string = "CSPFK040E Failed to parse annotations file"
 const CSPFK041E string = "CSPFK041E Failed to open annotations file '%s'. Reason: %s"
 const CSPFK042E string = "CSPFK042E Annotation '%s' does not accept value '%s': must be type %s"
 const CSPFK043E string = "CSPFK043E Annotation '%s' does not accept value '%s': only accepts %v"


### PR DESCRIPTION
On reviewing the error messages, there are two error messages used
for the same failure. One of these error messages can
be removed.


### Desired Outcome

The original error message from annotations.NewAnnotationsFromFile should be
passed through.

### Implemented Changes

secrets-provider/main calls  annotations.NewAnnotationsFromFile() and on an error
it returns messages.CSPFK040E. However, NewAnnotationsFromFile already
returns error message [CSPFK041E](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/pkg/secrets/annotations/annotation_parser.go#L36)
so a new error message is not needed and it just
hides the original error message.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

Works towards CyberArk internal issue link: [13741](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13741)
but does not resolve it.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
