### PR TITLE
List of paths to retrieve from Conjur should be a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   if it finds any pre-existing secret files. This is helpful when the Secrets
   Provider is being run multiple times.
   [cyberark/secrets-provider-for-k8s#397](https://github.com/cyberark/secrets-provider-for-k8s/pull/397)
+- If the Secrets Provider is run in Push-to-File mode, it no longer errors out
+  if either (a) multiple secret groups use the same secret path, or (b) there
+  are no secrets that need to be retrieved.
+  [cyberark/secrets-provider-for-k8s#404](https://github.com/cyberark/secrets-provider-for-k8s/pull/404)
 
 ## [1.2.0] - 2021-11-30
 

--- a/pkg/log/messages/info_messages.go
+++ b/pkg/log/messages/info_messages.go
@@ -27,3 +27,4 @@ const CSPFK012I string = "CSPFK012I Secrets Provider setting '%s' set by both en
 const CSPFK013I string = "CSPFK013I Gathering settings for Authenticator client configuration..."
 const CSPFK014I string = "CSPFK014I Authenticator setting %s provided by %s"
 const CSPFK015I string = "CSPFK015I DAP/Conjur Secrets pushed to shared volume successfully"
+const CSPFK016I string = "CSPFK016I There are no secrets to be retrieved from Conjur"

--- a/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
+++ b/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
@@ -60,6 +60,11 @@ func (retriever conjurSecretRetriever) Retrieve(variableIDs []string) (map[strin
 func retrieveConjurSecrets(accessToken []byte, variableIDs []string) (map[string][]byte, error) {
 	log.Info(messages.CSPFK003I, variableIDs)
 
+	if len(variableIDs) == 0 {
+		log.Info(messages.CSPFK016I)
+		return nil, nil
+	}
+
 	conjurClient, err := NewConjurClient(accessToken)
 	if err != nil {
 		return nil, log.RecordedError(messages.CSPFK033E)

--- a/pkg/secrets/pushtofile/retrieve_secrets.go
+++ b/pkg/secrets/pushtofile/retrieve_secrets.go
@@ -52,12 +52,26 @@ func FetchSecretsForGroups(
 	return secretsByGroup, err
 }
 
+// secretPathSet is a mathematical set of secret paths. The values of the
+// underlying map use an empty struct, since no data is required.
+type secretPathSet map[string]struct{}
+
+func (s secretPathSet) Add(path string) {
+	s[path] = struct{}{}
+}
+
 func getAllPaths(secretGroups []*SecretGroup) []string {
-	var ids []string
+	// Create a mathematical set of all secret paths
+	pathSet := secretPathSet{}
 	for _, group := range secretGroups {
 		for _, spec := range group.SecretSpecs {
-			ids = append(ids, spec.Path)
+			pathSet.Add(spec.Path)
 		}
 	}
-	return ids
+	// Convert the set of secret paths to a slice of secret paths
+	var paths []string
+	for path := range pathSet {
+		paths = append(paths, path)
+	}
+	return paths
 }

--- a/pkg/secrets/pushtofile/retrieve_secrets_test.go
+++ b/pkg/secrets/pushtofile/retrieve_secrets_test.go
@@ -145,3 +145,77 @@ func TestRetrieveSecrets(t *testing.T) {
 		tc.Run(t, m.Fetch)
 	}
 }
+
+func TestGetAllPaths(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		description        string
+		secretPathsByGroup map[string][]SecretSpec
+		expectedPaths      []string
+	}{
+		{
+			description: "Single secret group, no duplicated paths",
+			secretPathsByGroup: map[string][]SecretSpec{
+				"group-1": {
+					{Alias: "var1", Path: "path/var1"},
+					{Alias: "var2", Path: "path/var2"},
+				},
+			},
+			expectedPaths: []string{"path/var1", "path/var2"},
+		},
+		{
+			description: "Single secret group, duplicated path",
+			secretPathsByGroup: map[string][]SecretSpec{
+				"group-1": {
+					{Alias: "var1", Path: "path/var1"},
+					{Alias: "var2", Path: "path/var1"},
+				},
+			},
+			expectedPaths: []string{"path/var1"},
+		},
+		{
+			description: "Multiple secret groups, no duplicated path",
+			secretPathsByGroup: map[string][]SecretSpec{
+				"group-1": {
+					{Alias: "var1", Path: "path/var1"},
+					{Alias: "var2", Path: "path/var2"},
+				},
+				"group-2": {
+					{Alias: "var3", Path: "path/var3"},
+					{Alias: "var4", Path: "path/var4"},
+				},
+			},
+			expectedPaths: []string{"path/var1", "path/var2", "path/var3", "path/var4"},
+		},
+		{
+			description: "Multiple secret groups, duplicated path",
+			secretPathsByGroup: map[string][]SecretSpec{
+				"group-1": {
+					{Alias: "var1", Path: "path/var1"},
+					{Alias: "var2", Path: "path/var2"},
+				},
+				"group-2": {
+					{Alias: "var3", Path: "path/var1"},
+					{Alias: "var4", Path: "path/var4"},
+				},
+			},
+			expectedPaths: []string{"path/var1", "path/var2", "path/var4"},
+		},
+	}
+
+	for _, tc := range testCases {
+		// Set up a slice of SecretGroups to test
+		secretGroups := []*SecretGroup{}
+		for _, specs := range tc.secretPathsByGroup {
+			secretGroup := SecretGroup{}
+			secretGroup.SecretSpecs = append([]SecretSpec{}, specs...)
+			secretGroups = append(secretGroups, &secretGroup)
+		}
+
+		// Run test case
+		paths := getAllPaths(secretGroups)
+
+		// Verify results
+		assert.ElementsMatch(t, paths, tc.expectedPaths)
+	}
+}


### PR DESCRIPTION
### Desired Outcome

In Push-to-File mode, the Secrets Provider should not fail (crash) when either:

- Duplicated secret paths: A secret path is used in more than one secret group
- Empty secret path list: When there are no secrets to actually retrieve from Conjur

Currently, Secrets Provider in Push-to-File mode is crashing for both of these cases,
since Conjur is apparently intolerant of either duplicate secret paths being retrieved
or an empty list of secret paths to retrieve.

### Implemented Changes

- When secret paths are gathered across all secret groups, the paths are compiled
  into a **set** of secret paths, not simply an aggregated slice.
- Secrets retrieval from Conjur is skipped if there are no secrets to retrieve.

### Connected Issue/Story

### Definition of Done

- [x] Changes made to ensure list of secrets to retrieve from Conjur is guaranteed to contain unique entries
- [x] Changes are made to skip secret retrieval if there are no secrets to retrieve

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
