### PR TITLE
Add base64 encode / decode custom template functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Adds support for tracing with OpenTelemetry. [cyberark/secrets-provider-for-k8s#398](https://github.com/cyberark/secrets-provider-for-k8s/pull/398)
+- Adds support for Base64 encode/decode functions in custom templates. [cyberark/secrets-provider-for-k8s#409](https://github.com/cyberark/secrets-provider-for-k8s/pull/409)
 
 ### Fixed
 - If the Secrets Provider is run in Push-to-File mode, it no longer errors out

--- a/PUSH_TO_FILE.md
+++ b/PUSH_TO_FILE.md
@@ -515,6 +515,24 @@ respectively:
 For a full list of global Go text template functions, reference the official
 [`text/template` documentation](https://pkg.go.dev/text/template#hdr-Functions).
 
+### Additional Template Functions
+
+Custom templates also support a limited number of additional functions. Currently
+supported functions are:
+
+- `b64enc`: Base64 encode a value.
+- `b64dec`: Base64 decode a value.
+
+These can be used as follows:
+
+```
+{{ secret "alias" | b64enc }}
+{{ secret "alias" | b64dec }}
+```
+
+When using the `b64dec` function, an error will occur if the value retrieved from
+Conjur is not a valid Base64 encoded string.
+
 ### Execution "Double-Pass"
 
 To avoid leaking sensitive secret data to logs, and to ensure that a

--- a/pkg/secrets/pushtofile/push_to_writer.go
+++ b/pkg/secrets/pushtofile/push_to_writer.go
@@ -73,6 +73,8 @@ func pushToWriter(
 			// when the template is executed.
 			panic(fmt.Sprintf("secret alias %q not present in specified secrets for group", alias))
 		},
+		"b64enc": b64encTemplateFunc,
+		"b64dec": b64decTemplateFunc,
 	}).Parse(groupTemplate)
 	if err != nil {
 		return err

--- a/pkg/secrets/pushtofile/push_to_writer_test.go
+++ b/pkg/secrets/pushtofile/push_to_writer_test.go
@@ -66,6 +66,29 @@ var writeToFileTestCases = []pushToWriterTestCase{
 		assert:      assertGoodOutput("&#34; &#39; &amp; &lt; &gt; \uFFFD"),
 	},
 	{
+		description: "base64 encoding",
+		template:    `{{secret "alias" | b64enc}}`,
+		secrets:     []*Secret{{Alias: "alias", Value: "secret value"}},
+		assert:      assertGoodOutput("c2VjcmV0IHZhbHVl"),
+	},
+	{
+		description: "base64 decoding",
+		template:    `{{secret "alias" | b64dec}}`,
+		secrets:     []*Secret{{Alias: "alias", Value: "c2VjcmV0IHZhbHVl"}},
+		assert:      assertGoodOutput("secret value"),
+	},
+	{
+		description: "base64 decoding invalid input",
+		template:    `{{secret "alias" | b64dec}}`,
+		secrets:     []*Secret{{Alias: "alias", Value: "c2VjcmV0IHZhbHVl_invalid"}},
+		assert: func(t *testing.T, s string, err error) {
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "value could not be base64 decoded")
+			// Ensure the error doesn't contain the actual secret
+			assert.NotContains(t, err.Error(), "c2VjcmV0IHZhbHVl_invalid")
+		},
+	},
+	{
 		description: "iterate over secret key-value pairs",
 		template: `{{- range $index, $secret := .SecretsArray -}}
 {{- if $index }}

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -404,6 +404,18 @@ func TestNewSecretGroups(t *testing.T) {
 		assert.Contains(t, errs[0].Error(), `secret alias "x" not present in specified secrets`)
 	})
 
+	t.Run("pass custom format first-pass at execution with base64 decoding", func(t *testing.T) {
+		// The string "REDACTED" is valid Base64 so no error is produced in the first-pass.
+		_, errs := NewSecretGroups("/basepath", "", map[string]string{
+			"conjur.org/conjur-secrets.first":       "- path/to/secret/first1\n",
+			"conjur.org/secret-file-path.first":     "firstfilepath",
+			"conjur.org/secret-file-format.first":   "template",
+			"conjur.org/secret-file-template.first": `{{ secret "first1" | b64dec }}`,
+		})
+
+		assert.Len(t, errs, 0)
+	})
+
 	t.Run("custom template - happy case from template file", func(t *testing.T) {
 		// Setup mocks
 		closableBuf := new(ClosableBuffer)

--- a/pkg/secrets/pushtofile/template_functions.go
+++ b/pkg/secrets/pushtofile/template_functions.go
@@ -1,0 +1,26 @@
+package pushtofile
+
+import "encoding/base64"
+
+// Define template functions that don't need access to secrets in this file
+// to keep the push_to_writer.go file cleaner with only the functions that
+// require access to secrets.
+
+// b64enc is a custom template function for performing a base64 encode
+// on a secret value.
+func b64encTemplateFunc(value string) string {
+	return base64.StdEncoding.EncodeToString([]byte(value))
+}
+
+// b64dec is a custom template function for performing a base64 decode
+// on a secret value.
+func b64decTemplateFunc(encValue string) string {
+	decValue, err := base64.StdEncoding.DecodeString(encValue)
+	if err == nil {
+		return string(decValue)
+	}
+
+	// Panic in a template function is captured as an error
+	// when the template is executed.
+	panic("value could not be base64 decoded")
+}


### PR DESCRIPTION
### Desired Outcome

We would like to add support for two Golang template functions to allow users of Push to File custom templates to have the Secrets Provider perform base64 encoding and base64 decoding (respectively) on secrets retrieved from Conjur before rendering the secret values to a secret file.

### Implemented Changes

Added support for `b64enc` and `b64dec` template functions.
Implemented using the standard Golang encoding/base64 package.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14094](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14094)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
