### PR TITLE
Fix E2E for OpenShift and 500 internal server errors

### DIFF
--- a/deploy/config/openshift/test-env-push-to-file.sh.yml
+++ b/deploy/config/openshift/test-env-push-to-file.sh.yml
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -euo pipefail
+
+CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/*/*"}
+
+cat << EOL
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: test-env
+  name: test-env
+spec:
+  replicas: 1
+  selector:
+    app: test-env
+  template:
+    metadata:
+      labels:
+        app: test-env
+      annotations:
+        conjur.org/authn-identity: '$CONJUR_AUTHN_LOGIN'
+        conjur.org/container-mode: init
+        conjur.org/secrets-destination: file
+        conjur.org/debug-logging: "true"
+        conjur.org/retry-count-limit: "6"
+        conjur.org/retry-interval-sec: "2"
+        conjur.org/conjur-secrets.group1: |
+          - url: secrets/url
+          - username: secrets/username
+          - password: secrets/password
+        conjur.org/conjur-secrets-policy-path.group2: secrets
+        conjur.org/conjur-secrets.group2: |
+          - url: url
+          - username: username
+          - password: password
+        conjur.org/secret-file-format.group2: json
+        conjur.org/conjur-secrets-policy-path.group3: secrets
+        conjur.org/secret-file-path.group3: some-dotenv.env
+        conjur.org/conjur-secrets.group3: |
+          - url: url
+          - username: username
+          - password: password
+        conjur.org/secret-file-format.group3: dotenv
+        conjur.org/conjur-secrets.group4: |
+          - url: secrets/url
+          - username: secrets/username
+          - password: secrets/password
+        conjur.org/secret-file-format.group4: bash
+        conjur.org/secret-file-path.group5: group5.template
+        conjur.org/conjur-secrets.group5: |
+          - username: secrets/username
+          - password: secrets/password
+        conjur.org/secret-file-template.group5: |
+          username | {{ secret "username" }}
+          password | {{ secret "password" }}
+        conjur.org/secret-file-format.group5: template
+    spec:
+      containers:
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
+        name: test-app
+        command: ["sleep"]
+        args: ["infinity"]
+        volumeMounts:
+          - mountPath: /opt/secrets/conjur
+            name: conjur-secrets
+            readOnly: true
+      initContainers:
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+        imagePullPolicy: Always
+        name: cyberark-secrets-provider-for-k8s
+        volumeMounts:
+          - mountPath: /conjur/secrets
+            name: conjur-secrets
+          - mountPath: /conjur/podinfo
+            name: podinfo
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: CONJUR_APPLIANCE_URL
+            value: ${CONJUR_APPLIANCE_URL}
+
+          - name: CONJUR_AUTHN_URL
+            value: ${CONJUR_AUTHN_URL}
+
+          - name: CONJUR_ACCOUNT
+            value: ${CONJUR_ACCOUNT}
+
+          - name: CONJUR_SSL_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: conjur-master-ca-env
+                key: ssl-certificate
+
+      imagePullSecrets:
+        - name: dockerpullsecret
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: conjur-secrets
+      - downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations
+            path: annotations
+        name: podinfo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conjur-master-ca-env
+  label:
+    app: test-env
+data:
+  ssl-certificate: |
+$(echo "${CONJUR_SSL_CERTIFICATE}" | while read line; do printf "%20s%s\n" "" "$line"; done)
+EOL

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -11,7 +11,11 @@ main() {
 
 deployConjur() {
   pushd ..
-    git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    # Temporarily pull a branch that has Conjur:edge
+    # due to a bug that is fixed but not yet released.
+    # This will be removed once Conjur is released with the fix.
+    # git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch downgrade-conjur-version git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
     cmd="./start"
     if [ $CONJUR_DEPLOYMENT = "oss" ]; then

--- a/deploy/test/test_in_docker.sh
+++ b/deploy/test/test_in_docker.sh
@@ -37,7 +37,12 @@ deployConjur() {
   # from inside the container
   docker pull $CONJUR_APPLIANCE_IMAGE
 
-  git clone git@github.com:cyberark/kubernetes-conjur-deploy \
+  # Temporarily pull a branch that has Conjur edge
+  # due to a bug that is fixed but not yet released.
+  # This will be removed once Conjur is released with the fix.
+  # git clone git@github.com:cyberark/kubernetes-conjur-deploy \
+  #    kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+  git clone --single-branch --branch downgrade-conjur-version git@github.com:cyberark/kubernetes-conjur-deploy \
       kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
   cmd="./start"


### PR DESCRIPTION
### Desired Outcome

The E2E tests should run without errors.
The OpenShift E2E tests should pass for push to file.

### Implemented Changes

Push to file E2E tests are missing a file for Openshift.
Also added a temporary fix to address the Conjur error
`500 Internal Server Error` that has been causing the E2E tests to fail.

With the update to Conjur 1.14.2 we are now seeing the above error.
Temporarily using Conjur version 'edge' as the fix hasn't merged yet.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done

E2E tests pass.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
