### PR TITLE
Publish RedHat Image to Internal Registry

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -29,10 +29,15 @@ if [ "$GIT_DESCRIPTION" = "v${VERSION}" ]; then
     docker push "$REGISTRY/$IMAGE_NAME:$tag"
   done
 
+  # Publish RedHat image to Internal Registry
+  docker tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" "$REGISTRY/secrets-provider-for-k8s-redhat:${VERSION}"
+  docker push "$REGISTRY/secrets-provider-for-k8s-redhat:${VERSION}"
+
   # Publish only latest to Redhat Registries
   echo "Tagging and pushing ${REDHAT_IMAGE}"
   docker tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" "${REDHAT_IMAGE}:${VERSION}"
 
+  # Publish RedHat image to RedHat Registry
   if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
     # you can't push the same tag twice to redhat registry, so ignore errors
     if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then


### PR DESCRIPTION
### Desired Outcome
Push the RedHat Image to our Internal Registry to save a copy if something goes wrong with the RedHat Image.

### Implemented Changes
Created new Docker tag for RedHat Image with private registry
Pushed the new image to the internal registry

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-14640](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14640)

### Definition of Done
- [ ] Properly tag RedHat Image
- [x] Push image to Internal Registry

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
