### PR TITLE
Eliminate 500 internal server errors when configuring CLI Pod

### DIFF
--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -11,7 +11,11 @@ main() {
 
 deployConjur() {
   pushd ..
-    git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    # ***TEMP*** Use branch with fix for Conjur CLI 500 Internal Server Error
+    #git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --branch fix-cli-500-internal-err \
+      git@github.com:cyberark/kubernetes-conjur-deploy \
+      kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
     cmd="./start"
     if [ $CONJUR_DEPLOYMENT = "oss" ]; then

--- a/deploy/test/test_in_docker.sh
+++ b/deploy/test/test_in_docker.sh
@@ -37,8 +37,12 @@ deployConjur() {
   # from inside the container
   docker pull $CONJUR_APPLIANCE_IMAGE
 
-  git clone git@github.com:cyberark/kubernetes-conjur-deploy \
-      kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+  # ***TEMP*** Use branch with fix for Conjur CLI 500 Internal Server Error
+  #git clone git@github.com:cyberark/kubernetes-conjur-deploy \
+  #    kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+  git clone --branch fix-cli-500-internal-err \
+    git@github.com:cyberark/kubernetes-conjur-deploy \
+    kubernetes-conjur-deploy-$UNIQUE_TEST_ID
 
   cmd="./start"
   if [ $CONJUR_DEPLOYMENT = "oss" ]; then

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -191,7 +191,8 @@ configure_cli_pod() {
 
   $cli_with_timeout "exec $conjur_cli_pod -- bash -c \"yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url\""
 
-  $cli_with_timeout exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+  # Flaky with 500 Internal Server Error, mitigate with retry
+  wait_for_it 300 "$cli_with_timeout exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD"
 }
 
 configure_conjur_url() {


### PR DESCRIPTION
### Desired Outcome

Deploy scripts should not error out with the following error:

```
error: 500 Internal Server Error
```

when we're logging into Conjur via the Conjur CLI Pod. For more context, when we get to the point where the Conjur
CLI Pod is being configured (client cert initialized and log into
Conjur), we see the following error:

```
Configuring Conjur CLI.
++++++++++++++++++++++++++++++++++++++
Waiting for 'kubectl exec conjur-cli-854cf5d95d-d7vgp -- bash -c "yes yes | conjur init -a cucumber -u https://conjur-oss.local-conjur.svc.cluster.local"' up to 300 s
error: Unable to retrieve certificate from conjur-oss.local-conjur.svc.cluster.local:443
command terminated with exit code 1
.error: Unable to retrieve certificate from conjur-oss.local-conjur.svc.cluster.local:443
command terminated with exit code 1
.Trust this certificate (yes/no): Success!
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Created new account 'cucumber'
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Logged in
error: 500 Internal Server Error
command terminated with exit code 1
```

### Implemented Changes

The 500 internal server errors are apparently flaky. I do not know the root cause of the issue, but running the Conjur login inside a retry loop should fix the issue.

### Connected Issue/Story

### Definition of Done
- [ ] Secrets Provider builds are passing.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
