### PR TITLE
Update P2F error message for invalid Bash variable key

### DIFF
--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -57,10 +57,10 @@ func NewProviderForType(
 			providerConfig.TemplateFileBasePath,
 			providerConfig.AnnotationsMap,
 		)
-		provider.SetTraceContext(traceContext)
 		if err != nil {
 			return nil, err
 		}
+		provider.SetTraceContext(traceContext)
 		return provider.Provide, nil
 	default:
 		return nil, []error{fmt.Errorf(

--- a/pkg/secrets/pushtofile/secret_group.go
+++ b/pkg/secrets/pushtofile/secret_group.go
@@ -185,7 +185,8 @@ func (sg *SecretGroup) validate() []error {
 		if err != nil {
 			return []error{
 				fmt.Errorf(
-					"unable to process file format %q for group: %s",
+					"unable to process group %q into file format %q: %s",
+					groupName,
 					fileFormat,
 					err,
 				),

--- a/pkg/secrets/pushtofile/standard_templates.go
+++ b/pkg/secrets/pushtofile/standard_templates.go
@@ -37,11 +37,7 @@ func FileTemplateForFormat(
 	for _, s := range secretSpecs {
 		err := stdTemplate.ValidateAlias(s.Alias)
 		if err != nil {
-			return "", fmt.Errorf(
-				"alias %q failed standard file format validation: %s",
-				s.Alias,
-				err,
-			)
+			return "", err
 		}
 	}
 

--- a/pkg/secrets/pushtofile/standard_templates_test.go
+++ b/pkg/secrets/pushtofile/standard_templates_test.go
@@ -13,7 +13,7 @@ const (
 	invalidJSONChar    = "invalid JSON character"
 	yamlAliasTooLong   = "too long for YAML"
 	jsonAliasTooLong   = "too long for JSON"
-	invalidBashVarName = "Must be alphanumerics and underscores"
+	invalidBashVarName = "can only include alphanumerics and underscores"
 	validConjurPath    = "valid/conjur/variable/path"
 )
 

--- a/pkg/secrets/pushtofile/standard_templates_validate.go
+++ b/pkg/secrets/pushtofile/standard_templates_validate.go
@@ -83,8 +83,8 @@ func isValidJSONChar(c rune) bool {
 func validateBashVarName(name string) error {
 	r := regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 	if !r.MatchString(name) {
-		explanation := "Must be alphanumerics and underscores, with first char being a non-digit"
-		return fmt.Errorf("invalid alias '%s': %s", name, explanation)
+		explanation := "variable names can only include alphanumerics and underscores, with first char being a non-digit"
+		return fmt.Errorf("invalid alias %q: %s", name, explanation)
 	}
 	return nil
 }


### PR DESCRIPTION
### Desired Outcome

When using Push-to-File to render a secret file in format `bash`, if an invalid key is provided, the resulting error message
is repetitive and misleading:

```
Unable to process file format “bash” for group:
alias “{alias}” failed standard file format validation:
invalid alias ‘{alias}’:
Must be alphanumerics and underscores, with first char being a non-digit
```

### Implemented Changes

Now, invalid bash keys will return the error message:

```
Unable to process group “{group}” into file format "bash":
invalid alias “{alias}”:
Variable names can only include alphanumerics and underscores, with first char being a non-digit
```

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14674](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14674)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
