### PR TITLE
Fix Docker-based builds to work on CyberArk NG laptops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage.xml
 #ignore junit files
 junit.output
 junit.xml
+
+# Temporary directory to store the CyberArk proxy CA certificate
+build_ca_certificate/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,17 @@ ENV GOOS=linux \
     GOARCH=amd64 \
     CGO_ENABLED=0
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 RUN go get -u github.com/jstemmer/go-junit-report
 
 WORKDIR /opt/secrets-provider-for-k8s

--- a/bin/build
+++ b/bin/build
@@ -23,34 +23,45 @@ FULL_VERSION_TAG="$(full_version_tag)"
 
 echo "---"
 
-if [ $DEBUG = true ]; then
-  echo "Building secrets-provider-debug Docker image"
+function main() {
+  retrieve_cyberark_ca_cert
+  build_docker_image
+}
 
-  docker build \
-    --build-arg TAG="debug" \
-    --tag "secrets-provider-for-k8s-debug:latest" \
-    --target "secrets-provider-debug" \
-    .
-else
-  echo "Building secrets-provider-for-k8s:$FULL_VERSION_TAG Docker image"
+function build_docker_image() {
 
-  docker build \
-    --build-arg TAG=$(git_tag) \
-    --tag "secrets-provider-for-k8s:dev" \
-    --tag "secrets-provider-for-k8s:${FULL_VERSION_TAG}" \
-    --tag "secrets-provider-for-k8s:latest" \
-    --target "secrets-provider" \
-    .
+  if [ $DEBUG = true ]; then
+    echo "Building secrets-provider-debug Docker image"
 
-  echo "Building secrets-provider-for-k8s-redhat:$FULL_VERSION_TAG Docker image"
+    docker build \
+      --build-arg TAG="debug" \
+      --tag "secrets-provider-for-k8s-debug:latest" \
+      --target "secrets-provider-debug" \
+      .
+  else
+    echo "Building secrets-provider-for-k8s:$FULL_VERSION_TAG Docker image"
 
-  docker build \
-     --build-arg TAG=$(git_tag) \
-     --build-arg VERSION="$FULL_VERSION_TAG" \
-     --tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" \
-     --tag "secrets-provider-for-k8s-redhat:latest" \
-     --target "secrets-provider-for-k8s-redhat" \
-     .
-fi
+    docker build \
+      --build-arg TAG=$(git_tag) \
+      --tag "secrets-provider-for-k8s:dev" \
+      --tag "secrets-provider-for-k8s:${FULL_VERSION_TAG}" \
+      --tag "secrets-provider-for-k8s:latest" \
+      --target "secrets-provider" \
+      .
 
-echo "---"
+    echo "Building secrets-provider-for-k8s-redhat:$FULL_VERSION_TAG Docker image"
+
+    docker build \
+       --build-arg TAG=$(git_tag) \
+       --build-arg VERSION="$FULL_VERSION_TAG" \
+       --tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" \
+       --tag "secrets-provider-for-k8s-redhat:latest" \
+       --target "secrets-provider-for-k8s-redhat" \
+       .
+  fi
+
+  echo "---"
+
+}
+
+main

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -29,3 +29,31 @@ gen_versions() {
     echo $version
   done
 }
+
+function retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang module dependencies are downloaded with a
+  # corporate proxy in the middle. For these connections to succeed we need to
+  # configure the proxy CA certificate in build containers.
+  #
+  # To allow this script to also work on non-CyberArk laptops where the CA
+  # certificate is not available, we update container certificates based on
+  # a (potentially empty) certificate directory, rather than relying on the
+  # CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
+
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &> /dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}


### PR DESCRIPTION
### Desired Outcome

Fix Docker-based builds to work on CyberArk NG laptops.
(Background: On CyberArk dev laptops, golang module dependencies are downloaded with a corporate proxy in the middle. For these connections to succeed we need to configure the proxy CA certificate in build containers.)

### Implemented Changes

Ported part of [sidecar-injector PR#62](https://github.com/cyberark/sidecar-injector/pull/62).

### Connected Issue/Story

N/A

### Definition of Done
- Secrets provider docker images should build on an NG laptop.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
