### PR TITLE
Fix Docker-based unit tests to work on CyberArk NG laptops

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,6 +2,17 @@ FROM golang:1.17-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-test-runner"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /secrets-provider-for-k8s
 
 RUN apk add -u curl \

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -3,12 +3,24 @@
 set -eox pipefail
 
 junit_output_file="./junit.output"
+. bin/build_utils
 
-echo "Building unit test image..."
-docker build -f Dockerfile.test -t secrets-provider-for-k8s-test-runner:latest .
+function main() {
+  retrieve_cyberark_ca_cert
+  build_docker_ut_image
+  run_unit_tests
+  build_docker_junit_image
+  run_junit_report
+}
 
-echo "Running unit tests..."
-set +e
+function build_docker_ut_image() {
+  echo "Building unit test image..."
+  docker build -f Dockerfile.test -t secrets-provider-for-k8s-test-runner:latest .
+}
+
+function run_unit_tests() {
+  echo "Running unit tests..."
+  set +e
   docker run --rm -t \
              --volume "$PWD"/:/secrets-provider-for-k8s/test/ \
              secrets-provider-for-k8s-test-runner:latest \
@@ -17,20 +29,24 @@ set +e
              ./pkg/... \
              | tee -a "$junit_output_file"
   echo "Unit test exit status: $?"
-set -e
+}
 
-rm -f junit.xml
+function build_docker_junit_image() {
+  set -e
+  rm -f junit.xml
+  echo "Building junit image..."
+  docker build -f Dockerfile.junit -t secrets-provider-for-k8s-junit:latest .
+}
 
-echo "Building junit image..."
+function run_junit_report() {
+  echo "Creating junit report and coverage output XML"
+  docker run --rm \
+    -v $PWD/:/test \
+    secrets-provider-for-k8s-junit:latest \
+    bash -exc "
+      cat ./junit.output | go-junit-report > ./junit.xml ;
+      gocov convert ./c.out | gocov-xml > ./coverage.xml
+    "
+}
 
-docker build -f Dockerfile.junit -t secrets-provider-for-k8s-junit:latest .
-
-echo "Creating junit report and coverage output XML"
-
-docker run --rm \
-  -v $PWD/:/test \
-  secrets-provider-for-k8s-junit:latest \
-  bash -exc "
-    cat ./junit.output | go-junit-report > ./junit.xml ;
-    gocov convert ./c.out | gocov-xml > ./coverage.xml
-  "
+main


### PR DESCRIPTION
### Desired Outcome

Unit tests should run on CyberArk NG laptops.
On CyberArk dev laptops, golang module dependencies are downloaded with a corporate proxy in the middle. For these connections to succeed we need to configure the proxy CA certificate in build containers.

### Implemented Changes

[PR 424](https://github.com/cyberark/secrets-provider-for-k8s/pull/424) added changes to allow docker
builds to run on CyberArk laptops. This same issue is seen when running unit tests to the changes need
to be applied to the unit tests also.


### Connected Issue/Story

Resolves #

CyberArk internal issue link: 

### Definition of Done
- [x] Unit tests should run on a CyberArk laptop

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
