### PR TITLE
ONYX-16576: Add Authn-JWT support to helm

### DIFF
--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -27,8 +27,17 @@ spec:
       containers:
       - image: {{ .Values.secretsProvider.image }}:{{ .Values.secretsProvider.tag }}
         imagePullPolicy: {{ .Values.secretsProvider.imagePullPolicy }}
+        {{- if .Values.environment.conjur.authnJWT.projectToken}}
+        volumeMounts:
+          - name: jwt-token
+            mountPath: /var/run/secrets/tokens
+        {{- end }}
         name: {{ .Values.secretsProvider.name }}
         env:
+        {{- if .Values.environment.conjur.authnJWT.projectToken}}
+        - name: JWT_TOKEN_PATH
+          value: /var/run/secrets/tokens/{{ .Values.environment.conjur.authnJWT.projectedFilename }}
+        {{- end }}
         - name: MY_POD_NAME
           valueFrom:
             fieldRef:
@@ -91,5 +100,15 @@ spec:
         - configMapRef:
             name: {{ .Values.environment.conjur.conjurConnConfigMap }}
         {{- end }}
+      {{- if .Values.environment.conjur.authnJWT.projectToken}}
+      volumes:
+        - name: jwt-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: {{ .Values.environment.conjur.authnJWT.projectedFilename }}
+                  expirationSeconds: {{ .Values.environment.conjur.authnJWT.expiration }}
+                  audience: {{ .Values.environment.conjur.authnJWT.audience }}
+      {{- end }}
       restartPolicy: Never
   backoffLimit: 0

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -168,3 +168,37 @@ tests:
       - equal:
           path: metadata.name
           value: my-secrets-provider-job-name
+
+  #=======================================================================
+  - it: configures JWT token volume and volume mount if authn-jwt is enabled
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Enable authn-jwt authentication and set projected Filename
+      environment.conjur.authnJWT.projectToken: true
+      environment.conjur.authnJWT.projectedFilename: my-jwt-token-file
+
+    asserts:
+      # Confirm that the JWT token volume and volume mounts have been created
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: JWT_TOKEN_PATH
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: /var/run/secrets/tokens/my-jwt-token-file
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: jwt-token
+      - equal:
+          path: spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.path
+          value: my-jwt-token-file
+      - equal:
+          path: spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.expirationSeconds
+          value: 86400
+      - equal:
+          path: spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.audience
+          value: conjur

--- a/helm/secrets-provider/tests/test-schema
+++ b/helm/secrets-provider/tests/test-schema
@@ -138,6 +138,30 @@ function k8s_secrets_test() {
         --set "environment.k8sSecrets=$1"
 }
 
+function authn_jwt_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING" \
+        --set "environment.conjur.authnJWT.projectToken=true" \
+        --set "environment.conjur.authnJWT.projectedFilename=$1" \
+        --set "environment.conjur.authnJWT.audience=$2" \
+        --set "environment.conjur.authnJWT.expiration=$3"
+}
+
+function non_boolean_project_token_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_ACCOUNT_SETTING" \
+        --set "$DEFAULT_APPLIANCE_URL_SETTING" \
+        --set "$DEFAULT_AUTHN_LOGIN_SETTING" \
+        --set "$DEFAULT_AUTHN_URL_SETTING" \
+        --set "$DEFAULT_SSL_CERT_SETTING" \
+        --set "$DEFAULT_K8S_SECRETS_SETTING" \
+        --set "environment.conjur.authnJWT.projectToken=$1"
+}
+
 function missing_k8s_secrets_test() {
     helm lint . --strict \
         --set "$DEFAULT_ACCOUNT_SETTING" \
@@ -218,6 +242,22 @@ function main() {
 
     announce "Missing Conjur authn login causes failure"
     missing_conjur_authn_login_test
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Non-boolean value for projectToken is rejected"
+    non_boolean_project_token_test "not-a-boolean"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Null-string authn-jwt projected filename is rejected"
+    authn_jwt_test "" "conjur" 86400
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Null-string authn-jwt audience is rejected"
+    authn_jwt_test "jwt" "" 86400
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "A value of 0 for authn-jwt expiration is rejected"
+    authn_jwt_test "jwt" "conjur" 0
     update_results "$?" "$EXPECT_FAILURE"
 
     announce "Conjur authn URL that begins with 'https://' is accepted"

--- a/helm/secrets-provider/tests/test-unit
+++ b/helm/secrets-provider/tests/test-unit
@@ -8,7 +8,7 @@ cd "../$(dirname "$0")"
 
 source ./tests/utils.sh
 
-banner $BOLD "Running Helm unit tests for chart \"conjur-config-cluster-prep\""
+banner $BOLD "Running Helm unit tests for chart \"secrets-provider\""
 
 # Install the 'helm-unittest' plugin if it hasn't been install already
 if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then

--- a/helm/secrets-provider/values.schema.json
+++ b/helm/secrets-provider/values.schema.json
@@ -71,15 +71,31 @@
           }
         },
         "conjur": {
+          "if": {
+            "not": {
+              "properties": {
+                "authnJWT": {
+                  "properties": {
+                    "projectToken": {
+                      "enum": [ true ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "authnLogin"
+            ]
+          },
           "anyOf": [
             {
               "required": [
-                "authnLogin",
                 "conjurConnConfigMap"
               ]
             },{
               "required": [
-                "authnLogin",
                 "account",
                 "applianceUrl",
                 "authnUrl"
@@ -132,6 +148,26 @@
                 "value": {
                   "type": ["string","null"],
                   "minLength": 1
+                }
+              }
+            },
+            "authnJWT": {
+              "type": "object",
+              "properties": {
+                "projectToken": {
+                  "type": "boolean"
+                },
+                "projectedFilename": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "audience": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expiration": {
+                  "type": "number",
+                  "minimum": 1
                 }
               }
             }

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -84,3 +84,8 @@ environment:
     # This setting is required.
     #
     # authnLogin:
+    authnJWT:
+      projectToken: false
+      projectedFilename: jwt
+      audience: conjur
+      expiration: 86400 # This is one day in seconds


### PR DESCRIPTION
Changed helm chart to support token projection for JWT cases using this values.yaml 

```
environment:
  k8sSecrets:
  conjur: 
    account:
    applianceUrl:
    authnUrl:
    sslCertificate: 
      value:
    authnJWT:
      projectToken:
      projectedFilename:
      audience:
      expiration:
```