### PR TITLE
Update the secrets rotation UT

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -188,7 +188,7 @@ func retryableSecretsProvider(
 	// on this channel to trigger a graceful shut down of the Secrets Provider.
 	providerQuit := make(chan struct{})
 
-	provideSecrets = secrets.PeriodicSecretProvider(
+	provideSecrets = secrets.SecretProvider(
 		secretsConfig.SecretsRefreshInterval,
 		getContainerMode(),
 		provideSecrets,

--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -101,12 +101,12 @@ func RetryableSecretProvider(
 	}
 }
 
-// PeriodicSecretProvider returns a new ProviderFunc, which wraps a retryable
+// SecretProvider returns a new ProviderFunc, which wraps a retryable
 // ProviderFunc inside a function that operates in one of three modes:
 //  - Run once and return (for init or application container modes)
 //  - Run once and sleep forever (for sidecar mode without periodic refresh)
 //  - Run periodically (for sidecar mode with periodic refresh)
-func PeriodicSecretProvider(
+func SecretProvider(
 	secretRefreshInterval time.Duration,
 	mode string,
 	provideSecrets ProviderFunc,
@@ -150,6 +150,7 @@ func PeriodicSecretProvider(
 			// Kill the ticker
 			ticker.Stop()
 			periodicQuit <- struct{}{}
+			// Let the go routine exit
 			time.Sleep(secretProviderGracePeriod)
 		}
 		return err


### PR DESCRIPTION
### Desired Outcome

Update the UT for Secrets Provider rotation

### Implemented Changes

- Updated the UT to use a single mock provider with state.
- Modified the RetryableSecretProvider tests to use this as well.
- Renamed PeriodicSecretsProvider() to SecretsProvider() 

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-15539](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15539)

### Definition of Done
- [x] Run UT for the secrets provider periodic timer.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
