### PR TITLE
Bump Secrets Provider version to 1.4.0, and Helm chart version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] - 2022-02-15
+
 ### Added
 - Adds support for Secrets Provider secrets rotation feature, Community release.
   [cyberark/secrets-provider-for-k8s#426](https://github.com/cyberark/secrets-provider-for-k8s/pull/426)
+  [cyberark/secrets-provider-for-k8s#432](https://github.com/cyberark/secrets-provider-for-k8s/pull/432)
+- Adds support for Authn-JWT.
+  [cyberark/secrets-provider-for-k8s#431](https://github.com/cyberark/secrets-provider-for-k8s/pull/431)
+  [cyberark/secrets-provider-for-k8s#433](https://github.com/cyberark/secrets-provider-for-k8s/pull/433)
 
 ## [1.3.0] - 2022-01-03
 
@@ -192,7 +198,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.6...v1.2.0
 [1.1.6]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.1.5...v1.1.6

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -8,15 +8,16 @@ of the license associated with each component.
 
 Section 1: Apache-2.0
 >>> github.com/cyberark/conjur-api-go - v0.8.1
->>> github.com/cyberark/conjur-authn-k8s-client - v0.22.1-0.20220102093039-9e5b9cce0f03
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.23.0
+>>> github.com/cyberark/conjur-opentelemetry-tracer - v0.0.1-58
 >>> github.com/googleapis/gnostic - v0.5.5
 >>> github.com/modern-go/reflect2 - v1.0.2
 >>> gopkg.in/yaml.v2 - v2.4.0
 >>> gopkg.in/yaml.v3 - v3.0.0-20210107192922-496545a6307b
 >>> go.opentelemetry.io/otel - v1.3.0
->>> k8s.io/api - v0.23.1
->>> k8s.io/apimachinery - v0.23.1
->>> k8s.io/client-go - v0.23.1
+>>> k8s.io/api - v0.23.3
+>>> k8s.io/apimachinery - v0.23.3
+>>> k8s.io/client-go - v0.23.3
 >>> k8s.io/klog - v2.40.1
 >>> k8s.io/utils - v0.0.0-20211208161948-7d6a63dca704
 
@@ -61,7 +62,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/cyberark/conjur-authn-k8s-client - v0.22.1-0.20220102093039-9e5b9cce0f03
+>>> github.com/cyberark/conjur-authn-k8s-client - v0.23.0
+
+Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>>> github.com/cyberark/conjur-opentelemetry-tracer - v0.0.1-58
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
@@ -155,7 +172,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> k8s.io/api - v0.23.1
+>>> k8s.io/api - v0.23.3
 
 Copyright 2016-2018 The Kubernetes Authors
 
@@ -171,7 +188,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> k8s.io/apimachinery - v0.23.1
+>>> k8s.io/apimachinery - v0.23.3
 
 Copyright 2016 The Kubernetes Authors
 
@@ -187,7 +204,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/kubernetes/client-go - v0.23.1
+>>> k8s.io/client-go - v0.23.3
 
 Copyright 2020 The Kubernetes Authors
 
@@ -203,7 +220,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> github.com/kubernetes/klog - v2.40.1
+>>> k8s.io/klog - v2.40.1
 
 Copyright 2020 The Kubernetes Authors
 

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.3.0'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.0'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.3.0
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.0
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.3.0
+  tag: 1.4.0
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.3.0"
+var Version = "1.4.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Release Secrets Provider.

### Implemented Changes

- Bump Secrets Provider to v1.4.0. Includes:
  - Community level release of Secrets Rotation. This would warrant a patch level version bump, but...
  - Support for Authn-JWT.
- Bump Secrets Provider Helm chart to v1.4.1.
  - v1.4.0 added support for Authn-JWT configuration, but it used v1.3.0 of Secrets Provider, which did not yet support Authn-JWT.
  - Helm chart v1.4.1 will use v1.40 of Secrets Provider.

### Connected Issue/Story

N/A

### Definition of Done

- [x] Review and update `CHANGELOG.md` as needed
  - Added entry for Authn-JWT support
- [x] Review and update `NOTICES.txt` as needed
- [x] Update version:
  - `pkg/secrets/version.go`
  - `helm/secrets-provider/Chart.yaml`
  - `helm/secrets-provider/values.yaml`
  - `helm/secrets-provider/tests/secrets_provider_test.yaml`
  - `deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh`

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
