### PR TITLE
Fix OpenShift test for rotation

### DIFF
--- a/deploy/config/openshift/test-env-secrets-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-secrets-rotation.sh.yml
@@ -1,0 +1,136 @@
+#!/bin/bash
+set -euo pipefail
+
+CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/*/*"}
+
+cat << EOL
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: test-env
+  name: test-env
+spec:
+  replicas: 1
+  selector:
+    app: test-env
+  template:
+    metadata:
+      labels:
+        app: test-env
+      annotations:
+        conjur.org/authn-identity: '$CONJUR_AUTHN_LOGIN'
+        conjur.org/container-mode: "sidecar"
+        conjur.org/secrets-refresh-enabled: "true"
+        conjur.org/secrets-refresh-interval: "10s"
+        conjur.org/secrets-destination: file
+        conjur.org/debug-logging: "true"
+        conjur.org/retry-count-limit: "6"
+        conjur.org/retry-interval-sec: "2"
+        conjur.org/conjur-secrets.group1: |
+          - url: secrets/url
+          - username: secrets/username
+          - password: secrets/password
+          - test: secrets/test_secret
+        conjur.org/conjur-secrets-policy-path.group2: secrets
+        conjur.org/conjur-secrets.group2: |
+          - url: url
+          - username: username
+          - password: password
+          - test: test_secret
+        conjur.org/secret-file-format.group2: json
+        conjur.org/conjur-secrets-policy-path.group3: secrets
+        conjur.org/secret-file-path.group3: some-dotenv.env
+        conjur.org/conjur-secrets.group3: |
+          - url: url
+          - username: username
+          - password: password
+          - test: test_secret
+        conjur.org/secret-file-format.group3: dotenv
+        conjur.org/conjur-secrets.group4: |
+          - url: secrets/url
+          - username: secrets/username
+          - password: secrets/password
+          - test: secrets/test_secret
+        conjur.org/secret-file-format.group4: bash
+        conjur.org/secret-file-path.group5: group5.template
+        conjur.org/conjur-secrets.group5: |
+          - username: secrets/username
+          - password: secrets/password
+          - test: secrets/test_secret
+        conjur.org/secret-file-template.group5: |
+          username | {{ secret "username" }}
+          password | {{ secret "password" }}
+          test | {{ secret "test" }}
+        conjur.org/secret-file-format.group5: template
+    spec:
+      containers:
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
+        name: test-app
+        command: ["sleep"]
+        args: ["infinity"]
+        volumeMounts:
+          - mountPath: /opt/secrets/conjur
+            name: conjur-secrets
+            readOnly: true
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+        imagePullPolicy: Always
+        name: cyberark-secrets-provider-for-k8s
+        volumeMounts:
+          - mountPath: /conjur/secrets
+            name: conjur-secrets
+          - mountPath: /conjur/podinfo
+            name: podinfo
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: CONJUR_APPLIANCE_URL
+            value: ${CONJUR_APPLIANCE_URL}
+
+          - name: CONJUR_AUTHN_URL
+            value: ${CONJUR_AUTHN_URL}
+
+          - name: CONJUR_ACCOUNT
+            value: ${CONJUR_ACCOUNT}
+
+          - name: CONJUR_SSL_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: conjur-master-ca-env
+                key: ssl-certificate
+
+      imagePullSecrets:
+        - name: dockerpullsecret
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: conjur-secrets
+      - downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations
+            path: annotations
+        name: podinfo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conjur-master-ca-env
+  label:
+    app: test-env
+data:
+  ssl-certificate: |
+$(echo "${CONJUR_SSL_CERTIFICATE}" | while read line; do printf "%20s%s\n" "" "$line"; done)
+EOL


### PR DESCRIPTION
### Desired Outcome

Add missing test config for secrets rotation on OpenShift. OpenShift tests only run on "main", so this was not caught until after merging.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
