### PR TITLE
Don't overwrite secret file if atomic temp file not written

### DIFF
--- a/pkg/atomicwriter/atomic_writer.go
+++ b/pkg/atomicwriter/atomic_writer.go
@@ -15,15 +15,25 @@ type osFuncs struct {
 	chmod    func(string, os.FileMode) error
 	rename   func(string, string) error
 	remove   func(string) error
+	sync     func(*os.File) error
+	tempFile func(string, string) (*os.File, error)
 	truncate func(string, int64) error
+	write    func(*os.File, []byte) (int, error)
 }
 
 // Instantiation of OS Function table using std OS
 var stdOSFuncs = osFuncs{
-	chmod:    os.Chmod,
-	rename:   os.Rename,
-	remove:   os.Remove,
+	chmod:  os.Chmod,
+	rename: os.Rename,
+	remove: os.Remove,
+	sync: func(file *os.File) error {
+		return file.Sync()
+	},
+	tempFile: ioutil.TempFile,
 	truncate: os.Truncate,
+	write: func(file *os.File, content []byte) (int, error) {
+		return file.Write(content)
+	},
 }
 
 type atomicWriter struct {
@@ -33,43 +43,55 @@ type atomicWriter struct {
 	os          osFuncs
 }
 
-// This package provides a simple atomic file writer which implements the
-// io.WriteCloser interface. This allows us to use AtomicWriter the way we
+// NewAtomicWriter provides a simple atomic file writer which implements the
+// io.WriteCloser interface. This allows us to use the atomic writer the way we
 // would use any other Writer, such as a Buffer. Additonally, this struct
 // takes the file path during construction, so the code which calls
 // `Write()` doesn't need to be concerned with the destination, just like
 // any other writer.
-func NewAtomicWriter(path string, permissions os.FileMode) (io.WriteCloser, error) {
+func NewAtomicWriter(path string, permissions os.FileMode) io.WriteCloser {
 	return newAtomicWriter(path, permissions, stdOSFuncs)
 }
 
-func newAtomicWriter(path string, permissions os.FileMode, osFuncs osFuncs) (io.WriteCloser, error) {
-	dir, file := filepath.Split(path)
-
-	f, err := ioutil.TempFile(dir, file)
-	if err != nil {
-		log.Error(messages.CSPFK055E, path)
-		return nil, err
-	}
-
+func newAtomicWriter(path string, permissions os.FileMode, osFuncs osFuncs) io.WriteCloser {
 	return &atomicWriter{
 		path:        path,
-		tempFile:    f,
+		tempFile:    nil,
 		permissions: permissions,
 		os:          osFuncs,
-	}, nil
+	}
 }
 
 func (w *atomicWriter) Write(content []byte) (n int, err error) {
+	// Create a temporary file if not created already
+	if w.tempFile == nil {
+		dir, file := filepath.Split(w.path)
+
+		f, err := w.os.tempFile(dir, file)
+		if err != nil {
+			log.Error(messages.CSPFK055E, w.path)
+			return 0, err
+		}
+		w.tempFile = f
+	}
+
 	// Write to the temporary file
-	return w.tempFile.Write(content)
+	n, err = w.os.write(w.tempFile, content)
+	if err != nil {
+		log.Error(messages.CSPFK061E, w.path)
+		w.Cleanup()
+	}
+	return n, err
 }
 
 func (w *atomicWriter) Close() error {
+	if w.tempFile == nil {
+		return nil
+	}
 	defer w.Cleanup()
 
 	// Flush and close the temporary file
-	err := w.tempFile.Sync()
+	err := w.os.sync(w.tempFile)
 	if err != nil {
 		log.Error(messages.CSPFK056E, w.tempFile.Name())
 		return err
@@ -89,6 +111,7 @@ func (w *atomicWriter) Close() error {
 		log.Error(messages.CSPFK058E, w.tempFile.Name(), w.path)
 		return err
 	}
+	w.tempFile = nil
 
 	return nil
 }
@@ -97,18 +120,26 @@ func (w *atomicWriter) Close() error {
 // the `Close()` method, but can also be called manually in cases where `Close()`
 // is not called.
 func (w *atomicWriter) Cleanup() {
+	if w.tempFile == nil {
+		return
+	}
+
 	err := w.os.remove(w.tempFile.Name())
-	if err == nil {
+	if err == nil || os.IsNotExist(err) {
+		w.tempFile = nil
 		return
 	}
 
 	// If we can't remove the temporary directory, truncate the file to remove all secret content
 	err = w.os.truncate(w.tempFile.Name(), 0)
-	if err == nil || os.IsNotExist(err) {
+	switch {
+	case os.IsNotExist(err):
+		// This shouldn't happen, but just to be safe.
+		w.tempFile = nil
+	case err != nil:
+		// Truncate failed as well
+		log.Error(messages.CSPFK060E, w.tempFile.Name(), w.path)
+	default:
 		log.Error(messages.CSPFK059E, w.tempFile.Name(), w.path)
-		return
 	}
-
-	// If that failed as well, log the error
-	log.Error(messages.CSPFK060E, w.tempFile.Name(), w.path)
 }

--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -81,3 +81,4 @@ const CSPFK057E string = "CSPFK057E Could not set permissions on temporary file 
 const CSPFK058E string = "CSPFK058E Could not rename temporary file '%s' to '%s'"
 const CSPFK059E string = "CSPFK059E Could not delete temporary file '%s'. Truncated file."
 const CSPFK060E string = "CSPFK060E Could not delete temporary file '%s'. File may be left on disk."
+const CSPFK061E string = "CSPFK061E Could not write content to temporary file for '%s'"

--- a/pkg/secrets/pushtofile/push_to_writer.go
+++ b/pkg/secrets/pushtofile/push_to_writer.go
@@ -60,10 +60,7 @@ func openFileAsWriteCloser(path string, permissions os.FileMode) (io.WriteCloser
 	wc.Close()
 
 	// Return an instance of an atomic writer
-	atomicWriter, err := atomicwriter.NewAtomicWriter(path, permissions)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create atomic writer: %s", err)
-	}
+	atomicWriter := atomicwriter.NewAtomicWriter(path, permissions)
 
 	return atomicWriter, nil
 }


### PR DESCRIPTION
### Desired Outcome

When secret rotation is enabled in Push-to-File mode, and the Secrets Provider (periodically) checks for changes in secret files and finds no change in content, it correctly refrains from writing rendered file content to the temp file, as expected.

However, even though no content has been written to the temp file, there is a deferred call to the atomic file writer's Close() method that unconditionally renames the temp file to the destination secret file, effectively deleting the secret file content (i.e. overwriting the file with an empty file).

Here is a log showing this behavior:
```
INFO:  2022/03/04 23:28:34.506362 conjur_client.go:21: CSPFK002I Creating DAP/Conjur client
ERROR: 2022/03/04 23:28:34.597053 atomic_writer.go:108: CSPFK059E Could not delete temporary file '/conjur/secrets/dummy.yaml2445463986'. Truncated file.%!(EXTRA string=/conjur/secrets/dummy.yaml)
INFO:  2022/03/04 23:28:34.596982 push_to_writer.go:134: CSPFK018I No change in secret file, no secret files written
INFO:  2022/03/04 23:28:34.597159 push_to_writer.go:134: CSPFK018I No change in secret file, no secret files written
ERROR: 2022/03/04 23:28:34.597505 atomic_writer.go:108: CSPFK059E Could not delete temporary file '/conjur/secrets/application.yaml1889516433'. Truncated file.%!(EXTRA string=/conjur/secrets/application.yaml)
INFO:  2022/03/04 23:28:34.597514 provide_conjur_secrets.go:94: CSPFK015I DAP/Conjur Secrets pushed to shared volume successfully
```

And inside the container, the secret files have no content:
```
/conjur/secrets $ ls -l
total 0
-rw-r--r--    1 nobody   nobody           0 Mar  4 23:30 application.yaml
-rw-r--r--    1 nobody   nobody           0 Mar  4 23:30 dummy.yaml
/conjur/secrets $ 
```
The desired outcome is:
- The destination secret file shouldn't be overwritten (contents cleared) when secrets haven't changed.
- We shouldn't attempt to delete the temp file if it's been renamed to the target secret file name.

### Implemented Changes

- The secret file is no longer overwritten by the temp file if the temp file hasn't been written.
- Deleting of the temp file is no longer attempted if it's been renamed to the target secret file.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-17885](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17885)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
