### PR TITLE
Delete secrets files when retrieval fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Secrets files are written in an atomic operation. [cyberark/secrets-provider-for-k8s#440](https://github.com/cyberark/secrets-provider-for-k8s/pull/440)
+- Secret files are deleted when secrets are removed from Conjur or access is revoked. Can be disabled with annotation.
+  [cyberark/secrets-provider-for-k8s#447](https://github.com/cyberark/secrets-provider-for-k8s/pull/447)
 
 ## [1.4.0] - 2022-02-15
 

--- a/ROTATION.md
+++ b/ROTATION.md
@@ -51,6 +51,11 @@ how Push to File works.
    For example:
    If the duration is set to two seconds, but retrieving the secrets takes three second then the
    secrets will be updated every three seconds.
+
+   Note:
+   If one or more of the secrets have been removed from Conjur or have had access revoked, the Secrets Provider
+   will remove the secrets files from the shared volume. To disable this feature, set the
+   `conjur.org/remove-deleted-secrets-enabled` annotation to `false`.
 4. The Secrets Provider renders secret files for each secret group, and
    writes the resulting files to a volume that is shared with your application
    container. The Secrets Provider will rewrite the secret files if there are any changes.
@@ -110,6 +115,7 @@ below is a list of annotations that are needed for secrets rotation.
 | `conjur.org/container-mode`         | Allowed values: <ul><li>`init`</li><li>`application`</li><li>`sidecar`</li></ul>Defaults to `init`.<br>Must be set (or default) to `init` or `sidecar`for Push to File mode.|
 | `conjur.org/secrets-refresh-enabled`  | Set to `true` to enable Secrets Rotation. Defaults to `false` unless `conjur.org/secrets-rotation-interval` is explicitly set. Secrets Provider will exit with error if this is set to `false` and `conjur.org/secrets-rotation-interval` is set. |
 | `conjur.org/secrets-refresh-interval` | Set to a valid duration string as defined [here](https://pkg.go.dev/time#ParseDuration). Setting a time implicitly enables refresh. Valid time units are `s`, `m`, and `h` (for seconds, minutes, and hours, respectively). Some examples of valid duration strings:<ul><li>`5m`</li><li>`2h30m`</li><li>`48h`</li></ul>The minimum refresh interval is 1 second. A refresh interval of 0 seconds is treated as a fatal configuration error. The default refresh interval is 5 minutes. The maximum refresh interval is approximately 290 years. |
+| `conjur.org/remove-deleted-secrets-enabled` | Set to `false` to disable deletion of secrets files from the shared volume when a secret is removed or access is revoked in Conjur. Defaults to `true`. |
 
 ## Troubleshooting
 
@@ -128,9 +134,8 @@ To enable the debug logs, See [enable-logs](PUSH_TO_FILE.md#enable-logs)
 This feature is a **Community** level project that is still under development.
 There could be changes to the documentation so please check back often for updates and additions.
 Future enhancements to this feature will include:
+
 - Support for secrets rotation of Kubernetes secrets
 - atomic writes for multiple Conjur secret values
-- reporting of multiple errored secret variables for bulk Conjur secret retrieval
-- secret file deletion upon secret deleted / access being revoked
+- reporting of multiple errored secret variables for bulk Conjur secret retrieval and selective deletion of secret values from files
 - atomic write of secret files
-

--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -154,10 +154,11 @@ func retryableSecretsProvider(
 		span.RecordErrorAndSetStatus(err)
 		return nil, nil, err
 	}
-	providerConfig := &secrets.ProviderConfig{
+	providerConfig := &secretsConfigProvider.ProviderConfig{
 		StoreType:            secretsConfig.StoreType,
 		PodNamespace:         secretsConfig.PodNamespace,
 		RequiredK8sSecrets:   secretsConfig.RequiredK8sSecrets,
+		SanitizeEnabled:      secretsConfig.SanitizeEnabled,
 		SecretFileBasePath:   secretsBasePath,
 		TemplateFileBasePath: templatesBasePath,
 		AnnotationsMap:       annotationsMap,

--- a/deploy/policy/templates/conjur-delete-secret.template.sh.yml
+++ b/deploy/policy/templates/conjur-delete-secret.template.sh.yml
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+cat << EOL
+# Should be loaded into root
+- !policy
+  id: secrets
+  body:
+    - !delete
+      record: !variable test_secret
+EOL

--- a/pkg/log/messages/info_messages.go
+++ b/pkg/log/messages/info_messages.go
@@ -30,3 +30,4 @@ const CSPFK015I string = "CSPFK015I DAP/Conjur Secrets pushed to shared volume s
 const CSPFK016I string = "CSPFK016I There are no secrets to be retrieved from Conjur"
 const CSPFK017I string = "CSPFK017I Creating default file name for secret group '%s'"
 const CSPFK018I string = "CSPFK018I No change in secret file, no secret files written"
+const CSPFK019I string = "CSPFK019I Error fetching secrets, deleting secrets file"

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -284,7 +284,6 @@ func NewConfig(settings map[string]string) *Config {
 	// ignore errors here, if the interval string is null, zero is returned
 	refreshInterval, _ := time.ParseDuration(refreshIntervalStr)
 
-	// TODO: Should we only enable this when rotation is enabled?
 	sanitizeEnableStr := settings[RemoveDeletedSecretsKey]
 	sanitizeEnable := parseBoolFromStringOrDefault(sanitizeEnableStr, DefaultSanitizeEnabled)
 

--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -95,6 +95,13 @@ var validateAnnotationsTestCases = []validateAnnotationsTestCase{
 		assert: assertErrorInList(fmt.Errorf(messages.CSPFK042E, retryCountLimitKey, "seven", "Integer")),
 	},
 	{
+		description: "when an annotation expects a bool but is given a non-bool value, an error is returned",
+		annotations: map[string]string{
+			RemoveDeletedSecretsKey: "10",
+		},
+		assert: assertErrorInList(fmt.Errorf(messages.CSPFK042E, RemoveDeletedSecretsKey, "10", "Boolean")),
+	},
+	{
 		description: "when an annotation expects a boolean but is given a non-boolean value, an error is returned",
 		annotations: map[string]string{
 			debugLoggingKey: "not-a-boolean",
@@ -195,6 +202,7 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 			retryCountLimitKey:                    "10",
 			retryIntervalSecKey:                   "20",
 			k8sSecretsKey:                         "- secret-1\n- secret-2\n- secret-3\n",
+			RemoveDeletedSecretsKey:               "true",
 			"conjur.org/container-mode":           "sidecar",
 			"conjur.org/secrets-refresh-interval": "5m",
 			"conjur.org/secrets-refresh-enabled":  "true",
@@ -412,11 +420,12 @@ var newConfigTestCases = []newConfigTestCase{
 	{
 		description: "a valid map of annotation-based Secrets Provider settings returns a valid Config",
 		settings: map[string]string{
-			"MY_POD_NAMESPACE":    "test-namespace",
-			SecretsDestinationKey: "k8s_secrets",
-			k8sSecretsKey:         "- secret-1\n- secret-2\n- secret-3\n",
-			retryCountLimitKey:    "10",
-			retryIntervalSecKey:   "20",
+			"MY_POD_NAMESPACE":      "test-namespace",
+			SecretsDestinationKey:   "k8s_secrets",
+			k8sSecretsKey:           "- secret-1\n- secret-2\n- secret-3\n",
+			retryCountLimitKey:      "10",
+			retryIntervalSecKey:     "20",
+			RemoveDeletedSecretsKey: "false",
 		},
 		assert: assertGoodConfig(&Config{
 			PodNamespace:       "test-namespace",
@@ -424,7 +433,7 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{"secret-1", "secret-2", "secret-3"},
 			RetryCountLimit:    10,
 			RetryIntervalSec:   20,
-			SanitizeEnabled:    DefaultSanitizeEnabled,
+			SanitizeEnabled:    false,
 		}),
 	},
 	{

--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -172,10 +172,10 @@ var gatherSecretsProviderSettingsTestCases = []gatherSecretsProviderSettingsTest
 			"UNRELATED_ENVVAR":  "unrelated-value",
 		},
 		assert: assertGoodMap(map[string]string{
-			SecretsDestinationKey: "file",
-			"conjur.org/container-mode":      "init",
-			"MY_POD_NAMESPACE":               "test-namespace",
-			"RETRY_COUNT_LIMIT":              "5",
+			SecretsDestinationKey:       "file",
+			"conjur.org/container-mode": "init",
+			"MY_POD_NAMESPACE":          "test-namespace",
+			"RETRY_COUNT_LIMIT":         "5",
 		}),
 	},
 }
@@ -375,7 +375,7 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 	{
 		description: "if refresh interval is negative, an error is returned",
 		envAndAnnots: map[string]string{
-			"MY_POD_NAMESPACE":               "test-namespace",
+			"MY_POD_NAMESPACE":        "test-namespace",
 			SecretsRefreshIntervalKey: "-5s",
 			ContainerModeKey:          "sidecar",
 		},
@@ -384,7 +384,7 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 	{
 		description: "if refresh interval is set and enable is false",
 		envAndAnnots: map[string]string{
-			"MY_POD_NAMESPACE":                    "test-namespace",
+			"MY_POD_NAMESPACE":        "test-namespace",
 			SecretsRefreshIntervalKey: "5s",
 			SecretsRefreshEnabledKey:  "false",
 			ContainerModeKey:          "sidecar",
@@ -412,11 +412,11 @@ var newConfigTestCases = []newConfigTestCase{
 	{
 		description: "a valid map of annotation-based Secrets Provider settings returns a valid Config",
 		settings: map[string]string{
-			"MY_POD_NAMESPACE":               "test-namespace",
+			"MY_POD_NAMESPACE":    "test-namespace",
 			SecretsDestinationKey: "k8s_secrets",
 			k8sSecretsKey:         "- secret-1\n- secret-2\n- secret-3\n",
-			retryCountLimitKey:   "10",
-			retryIntervalSecKey:  "20",
+			retryCountLimitKey:    "10",
+			retryIntervalSecKey:   "20",
 		},
 		assert: assertGoodConfig(&Config{
 			PodNamespace:       "test-namespace",
@@ -424,6 +424,7 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{"secret-1", "secret-2", "secret-3"},
 			RetryCountLimit:    10,
 			RetryIntervalSec:   20,
+			SanitizeEnabled:    DefaultSanitizeEnabled,
 		}),
 	},
 	{
@@ -441,15 +442,16 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{"secret-1", "secret-2", "secret-3"},
 			RetryCountLimit:    10,
 			RetryIntervalSec:   20,
+			SanitizeEnabled:    DefaultSanitizeEnabled,
 		}),
 	},
 	{
 		description: "settings configured with both annotations and envVars defer to the annotation value",
 		settings: map[string]string{
-			"MY_POD_NAMESPACE":               "test-namespace",
-			"SECRETS_DESTINATION":            "k8s_secrets",
+			"MY_POD_NAMESPACE":    "test-namespace",
+			"SECRETS_DESTINATION": "k8s_secrets",
 			SecretsDestinationKey: "file",
-			"K8S_SECRETS":                    "secret-1,secret-2,secret-3",
+			"K8S_SECRETS":         "secret-1,secret-2,secret-3",
 		},
 		assert: assertGoodConfig(&Config{
 			PodNamespace:       "test-namespace",
@@ -457,16 +459,17 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{},
 			RetryCountLimit:    DefaultRetryCountLimit,
 			RetryIntervalSec:   DefaultRetryIntervalSec,
+			SanitizeEnabled:    DefaultSanitizeEnabled,
 		}),
 	},
 	{
 		description: "mixed-source config",
 		settings: map[string]string{
-			"MY_POD_NAMESPACE":               "test-namespace",
+			"MY_POD_NAMESPACE":    "test-namespace",
 			SecretsDestinationKey: "k8s_secrets",
-			"RETRY_COUNT_LIMIT":              "10",
-			retryIntervalSecKey:  "20",
-			"K8S_SECRETS":                    "secret-1,secret-2,secret-3",
+			"RETRY_COUNT_LIMIT":   "10",
+			retryIntervalSecKey:   "20",
+			"K8S_SECRETS":         "secret-1,secret-2,secret-3",
 		},
 		assert: assertGoodConfig(&Config{
 			PodNamespace:       "test-namespace",
@@ -474,22 +477,24 @@ var newConfigTestCases = []newConfigTestCase{
 			RequiredK8sSecrets: []string{"secret-1", "secret-2", "secret-3"},
 			RetryCountLimit:    10,
 			RetryIntervalSec:   20,
+			SanitizeEnabled:    DefaultSanitizeEnabled,
 		}),
 	},
 	{
 		description: "a valid map of annotation-based settings with refresh enabled returns a valid Config",
 		settings: map[string]string{
-			"MY_POD_NAMESPACE":               "test-namespace",
-			SecretsDestinationKey: "file",
-			SecretsRefreshEnabledKey:  "true",
+			"MY_POD_NAMESPACE":       "test-namespace",
+			SecretsDestinationKey:    "file",
+			SecretsRefreshEnabledKey: "true",
 		},
 		assert: assertGoodConfig(&Config{
-			PodNamespace:       "test-namespace",
-			StoreType:          "file",
-			RequiredK8sSecrets: []string{},
-			RetryCountLimit:    5,
-			RetryIntervalSec:   1,
+			PodNamespace:           "test-namespace",
+			StoreType:              "file",
+			RequiredK8sSecrets:     []string{},
+			RetryCountLimit:        5,
+			RetryIntervalSec:       1,
 			SecretsRefreshInterval: DefaultRefreshInterval,
+			SanitizeEnabled:        DefaultSanitizeEnabled,
 		}),
 	},
 }

--- a/pkg/secrets/provide_conjur_secrets.go
+++ b/pkg/secrets/provide_conjur_secrets.go
@@ -20,22 +20,6 @@ const (
 	secretProviderGracePeriod = time.Duration(10 * time.Millisecond)
 )
 
-// ProviderConfig provides the configuration necessary to create a secrets
-// Provider.
-type ProviderConfig struct {
-	// Config common to all providers
-	StoreType string
-
-	// Config specific to Kubernetes Secrets provider
-	PodNamespace       string
-	RequiredK8sSecrets []string
-
-	// Config specific to Push to File provider
-	SecretFileBasePath   string
-	TemplateFileBasePath string
-	AnnotationsMap       map[string]string
-}
-
 // ProviderFunc describes a function type responsible for providing secrets to an unspecified target.
 type ProviderFunc func() error
 
@@ -43,7 +27,7 @@ type ProviderFunc func() error
 func NewProviderForType(
 	traceContext context.Context,
 	secretsRetrieverFunc conjur.RetrieveSecretsFunc,
-	providerConfig ProviderConfig,
+	providerConfig config.ProviderConfig,
 ) (ProviderFunc, []error) {
 	switch providerConfig.StoreType {
 	case config.K8s:
@@ -57,9 +41,7 @@ func NewProviderForType(
 	case config.File:
 		provider, err := pushtofile.NewProvider(
 			secretsRetrieverFunc,
-			providerConfig.SecretFileBasePath,
-			providerConfig.TemplateFileBasePath,
-			providerConfig.AnnotationsMap,
+			&providerConfig,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/clients/conjur"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +55,13 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tc := range TestCases {
 		t.Run(tc.description, func(t *testing.T) {
-			p, err := NewProvider(tc.retrieveFunc, tc.basePath, "", tc.annotations)
+			p, err := NewProvider(
+				tc.retrieveFunc,
+				&config.ProviderConfig{
+					SecretFileBasePath: tc.basePath,
+					AnnotationsMap:     tc.annotations,
+				},
+			)
 			assert.Empty(t, err)
 			assert.Equal(t, tc.expectedSecretGroup, p.secretGroups)
 		})
@@ -113,6 +120,7 @@ func TestProvideWithDeps(t *testing.T) {
 			err := provideWithDeps(
 				context.Background(),
 				tc.provider.secretGroups,
+				true,
 				fileProviderDepFuncs{
 					retrieveSecretsFunc: tc.provider.retrieveSecretsFunc,
 					depOpenWriteCloser:  spyOpenWriteCloser.Call,

--- a/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
@@ -3,6 +3,7 @@ package pushtofile
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/clients/conjur"
@@ -16,6 +17,31 @@ func retrieve(variableIDs []string, ctx context.Context) (map[string][]byte, err
 		masterMap[id] = []byte(fmt.Sprintf("value-%s", id))
 	}
 	return masterMap, nil
+}
+
+func retrieveWith403(variableIDs []string, ctx context.Context) (map[string][]byte, error) {
+	return nil, fmt.Errorf("403")
+}
+
+func retrieveWithGenericError(variableIDs []string, ctx context.Context) (map[string][]byte, error) {
+	return nil, fmt.Errorf("generic error")
+}
+
+func secretGroups(filePath string) []*SecretGroup {
+	return []*SecretGroup{
+		{
+			Name:            "groupname",
+			FilePath:        filePath,
+			FileFormat:      "yaml",
+			FilePermissions: 123,
+			SecretSpecs: []SecretSpec{
+				{
+					Alias: "password",
+					Path:  "path1",
+				},
+			},
+		},
+	}
 }
 
 func TestNewProvider(t *testing.T) {
@@ -70,29 +96,19 @@ func TestNewProvider(t *testing.T) {
 
 func TestProvideWithDeps(t *testing.T) {
 	TestCases := []struct {
-		description string
-		provider    fileProvider
-		assert      func(*testing.T, fileProvider, error, *ClosableBuffer, pushToWriterSpy, openWriteCloserSpy)
+		description     string
+		provider        fileProvider
+		createFileName  string
+		sanitizeEnabled bool
+		assert          func(*testing.T, fileProvider, error, *ClosableBuffer, pushToWriterSpy, openWriteCloserSpy)
 	}{
 		{
 			description: "happy path",
 			provider: fileProvider{
 				retrieveSecretsFunc: retrieve,
-				secretGroups: []*SecretGroup{
-					{
-						Name:            "groupname",
-						FilePath:        "/path/to/file",
-						FileFormat:      "yaml",
-						FilePermissions: 123,
-						SecretSpecs: []SecretSpec{
-							{
-								Alias: "password",
-								Path:  "path1",
-							},
-						},
-					},
-				},
+				secretGroups:        secretGroups("/path/to/file"),
 			},
+			sanitizeEnabled: true,
 			assert: func(
 				t *testing.T,
 				p fileProvider,
@@ -106,6 +122,69 @@ func TestProvideWithDeps(t *testing.T) {
 				assert.Nil(t, err)
 			},
 		},
+		{
+			description:    "403 error",
+			createFileName: "path_to_file.yaml",
+			provider: fileProvider{
+				retrieveSecretsFunc: retrieveWith403,
+				secretGroups:        secretGroups("path_to_file.yaml"),
+			},
+			sanitizeEnabled: true,
+			assert: func(
+				t *testing.T,
+				p fileProvider,
+				err error,
+				closableBuf *ClosableBuffer,
+				spyPushToWriter pushToWriterSpy,
+				spyOpenWriteCloser openWriteCloserSpy,
+			) {
+				assert.Error(t, err)
+				// File should be deleted because of 403 error
+				assert.NoFileExists(t, "path_to_file.yaml")
+			},
+		},
+		{
+			description:    "generic error",
+			createFileName: "path_to_file.yaml",
+			provider: fileProvider{
+				retrieveSecretsFunc: retrieveWithGenericError,
+				secretGroups:        secretGroups("path_to_file.yaml"),
+			},
+			sanitizeEnabled: true,
+			assert: func(
+				t *testing.T,
+				p fileProvider,
+				err error,
+				closableBuf *ClosableBuffer,
+				spyPushToWriter pushToWriterSpy,
+				spyOpenWriteCloser openWriteCloserSpy,
+			) {
+				assert.Error(t, err)
+				// File should not be deleted because of generic error
+				assert.FileExists(t, "path_to_file.yaml")
+			},
+		},
+		{
+			description:    "403 error with sanitize disabled",
+			createFileName: "path_to_file.yaml",
+			provider: fileProvider{
+				retrieveSecretsFunc: retrieveWith403,
+				secretGroups:        secretGroups("path_to_file.yaml"),
+			},
+			sanitizeEnabled: false,
+			assert: func(
+				t *testing.T,
+				p fileProvider,
+				err error,
+				closableBuf *ClosableBuffer,
+				spyPushToWriter pushToWriterSpy,
+				spyOpenWriteCloser openWriteCloserSpy,
+			) {
+				assert.Error(t, err)
+				// File shouldn't be deleted because sanitize is disabled
+				assert.FileExists(t, "path_to_file.yaml")
+			},
+		},
 	}
 
 	for _, tc := range TestCases {
@@ -117,10 +196,16 @@ func TestProvideWithDeps(t *testing.T) {
 				writeCloser: closableBuf,
 			}
 
+			if tc.createFileName != "" {
+				_, err := os.Create(tc.createFileName)
+				assert.NoError(t, err)
+				defer os.Remove(tc.createFileName)
+			}
+
 			err := provideWithDeps(
 				context.Background(),
 				tc.provider.secretGroups,
-				true,
+				tc.sanitizeEnabled,
 				fileProviderDepFuncs{
 					retrieveSecretsFunc: tc.provider.retrieveSecretsFunc,
 					depOpenWriteCloser:  spyOpenWriteCloser.Call,


### PR DESCRIPTION
### Desired Outcome

Delete secret file if Conjur returns a 403 or 404 status code.

### Implemented Changes

When secrets rotation is enabled, if a batch fetch call to Conjur fails during a refresh due to a deleted secret or revoked access, delete the secrets files from the shared volume to avoid leaving unauthorized secrets on the file system. Currently there's no support for specifying which secret(s) failed, so we need to delete all secrets included in the fetch, which includes all secret groups. A future effort will improve this.
This feature can be disabled using an annotation, `conjur.org/remove-deleted-secrets-enabled: "false"`.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-17938](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17938)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

- [x] Secret files are deleted if a secret doesn't exist or isn't authorized
- [x] An annotation exists to disable this functionality
- [x] UT exists
- [x] Integration tests exist

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
