### PR TITLE
Implement detection of changes in K8s Secret content with UT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/secrets-provider-for-k8s#447](https://github.com/cyberark/secrets-provider-for-k8s/pull/447)
 - Secrets Provider allows for its status to be monitored through the creation of a couple of empty sentinel files: `CONJUR_SECRETS_PROVIDED` and `CONJUR_SECRETS_UPDATED`. The first file is created when SP has completed its first round of providing secrets via secret files / Kubernetes Secrets. It creates/recreates the second file whenever it has updated secret files / Kubernetes Secrets. If desirable, application containers can mount these files via a shared volume.
   [cyberark/secrets-provider-for-k8s#450](https://github.com/cyberark/secrets-provider-for-k8s/pull/450)
+- Adds support for secrets rotation with Kubernetes Secrets.
+  [cyberark/secrets-provider-for-k8s#448](https://github.com/cyberark/secrets-provider-for-k8s/pull/448)
 
 ## [1.4.0] - 2022-02-15
 

--- a/ROTATION.md
+++ b/ROTATION.md
@@ -71,7 +71,15 @@ There are two new annotations introduced and one annotation is updated.
 Prerequisites:
 
 Requires secrets-provider-for-k8s v1.4.0 or later.
+
+<details><summary>For Push to File mode</summary>
+
 Follow the procedure to set up Secrets Provider for [Push to File](PUSH_TO_FILE.md#set-up-secrets-provider-for-push-to-file)
+</details>
+<details><summary>For Kubernetes Secrets mode</summary>
+
+Follow the procedure to set up [Kubernetes Secrets](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Integrations/k8s-ocp/cjr-k8s-secrets-provider-ic.htm?tocpath=Integrations%7COpenShift%252FKubernetes%7CSet%20up%20applications%7CSecrets%20Provider%20for%20Kubernetes%7CInit%20container%7C_____1#SetupSecretsProviderasaninitcontainer)
+</details>
 
 Modify the Kubernetes manifest
 1. Change the Secrets provider container to be a sidecar. If it was configured
@@ -135,7 +143,5 @@ This feature is a **Community** level project that is still under development.
 There could be changes to the documentation so please check back often for updates and additions.
 Future enhancements to this feature will include:
 
-- Support for secrets rotation of Kubernetes secrets
 - atomic writes for multiple Conjur secret values
 - reporting of multiple errored secret variables for bulk Conjur secret retrieval and selective deletion of secret values from files
-- atomic write of secret files

--- a/pkg/log/messages/info_messages.go
+++ b/pkg/log/messages/info_messages.go
@@ -31,3 +31,4 @@ const CSPFK016I string = "CSPFK016I There are no secrets to be retrieved from Co
 const CSPFK017I string = "CSPFK017I Creating default file name for secret group '%s'"
 const CSPFK018I string = "CSPFK018I No change in secret file, no secret files written"
 const CSPFK019I string = "CSPFK019I Error fetching secrets, deleting secrets file"
+const CSPFK020I string = "CSPFK020I No change in Kubernetes secret, no secrets updated"

--- a/pkg/secrets/k8s_secrets_storage/mocks/logger.go
+++ b/pkg/secrets/k8s_secrets_storage/mocks/logger.go
@@ -43,6 +43,11 @@ func (l *Logger) Info(msg string, args ...interface{}) {
 	l.infos = append(l.infos, fmt.Sprintf(msg, args...))
 }
 
+// ClearInfo Clears the info messages
+func (l *Logger) ClearInfo() {
+	l.infos = nil
+}
+
 // Debug logs a debug message.
 func (l *Logger) Debug(msg string, args ...interface{}) {
 	l.debugs = append(l.debugs, fmt.Sprintf(msg, args...))

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -898,7 +899,7 @@ func TestSecretGroup_PushToFile(t *testing.T) {
 			absoluteFilePath := path.Join(dir, tc.path)
 
 			// Reset the P2F cache so the files will be written even if the values haven't changed
-			prevFileChecksums = map[string]checksum{}
+			prevFileChecksums = map[string]utils.Checksum{}
 
 			// Create a group, and push to file
 			group := SecretGroup{

--- a/pkg/utils/checksum.go
+++ b/pkg/utils/checksum.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+)
+
+type Checksum []byte
+
+func FileChecksum(buf *bytes.Buffer) (Checksum, error) {
+	hash := sha256.New()
+	bufCopy := bytes.NewBuffer(buf.Bytes())
+	if _, err := io.Copy(hash, bufCopy); err != nil {
+		return nil, err
+	}
+	checksum := hash.Sum(nil)
+	return checksum, nil
+}
+
+func ContentHasChanged(groupName string, newChecksum Checksum, prevChecksums map[string]Checksum) bool {
+	if prevChecksum, exists := prevChecksums[groupName]; exists {
+		if bytes.Equal(newChecksum, prevChecksum) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/utils/checksum_test.go
+++ b/pkg/utils/checksum_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestChecksum(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		file := []byte("environment: prod\n" +
+			"url: https://example.com\n" +
+			"username: example-user\n" +
+			"password: example-pass\n")
+		expected := "e218dd95515fe368b6befe4b39f381fb82391d4f11b690225f27c9fcfe60d78b"
+		t.Run("Happy Case for FileChecksum", func(t *testing.T) {
+			b:=bytes.NewBuffer(file)
+			checksum, err := FileChecksum(b)
+			encodedChecksum := hex.EncodeToString(checksum)
+			assert.Equal(t, expected, encodedChecksum)
+			assert.NoError(t, err)
+		})
+		t.Run("No change case for ContentHasChanged", func(t *testing.T) {
+			prevChecksums := map[string]Checksum{}
+			group := "testGroup"
+			checksum1 := []byte("e218dd95515fe368b6befe4b39f381fb")
+			checksum2 := []byte("82391d4f11b690225f27c9fcfe60d78b")
+			prevChecksums[group] = checksum1
+			prevChecksums[group + "2"] = checksum2
+			assert.False(t, ContentHasChanged(group, checksum1, prevChecksums))
+		})
+		t.Run("Change case for ContentHasChanged", func(t *testing.T) {
+			prevChecksums := map[string]Checksum{}
+			group := "testGroup"
+			checksum1 := []byte("e218dd95515fe368b6befe4b39f381fb")
+			checksum2 := []byte("82391d4f11b690225f27c9fcfe60d78b")
+			prevChecksums[group] = checksum1
+			prevChecksums[group + "2"] = checksum2
+			assert.True(t, ContentHasChanged(group, []byte("abcddd95515fe368b6befe4b39f381fb"), prevChecksums))
+		})
+	})
+}


### PR DESCRIPTION
### Desired Outcome

The Kubernetes secrets should only be updated when there is new content.

### Implemented Changes

Updated to detect changes the k8s secrets values and Conjur secrets.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-17475](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17475)

### Definition of Done
- [] K8s secrets are updated only when there are changes in the k8s secrets content or Conjur secrets.
#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
