### PR TITLE
Add note about the optional use of Reloader for app container restart

### DIFF
--- a/design/secret_rotation_design.md
+++ b/design/secret_rotation_design.md
@@ -257,7 +257,21 @@ Annotation-based configuration independent of operating modes.
     in this status file is detected, the file watcher can reset all
     processes in the application container.
 
-  - **OPTION 3: FUTURE SUPPORT: Configure Secrets Provider to Send Restart Signal**
+    NOTE: It would be rather convenient if we include the `inotify` binary
+    in the Secrets Provider Docker container image, and copy this to the
+    `/conjur/status` directory. This would make the `inotify` binary
+    available to use e.g. in `livenessProbe` definitions for application
+    containers. (This would require a `volumeMount` for the application
+    container to make the `inotify` binary available for the liveness probe).
+
+  - **OPTION 3: (For Kubernetes Secrets Mode Only) Use Kubernetes Reloader**
+    For applications that are using the Secrets Provider in Kubernetes Secrets
+    mode, the [Kubernetes Reloader](https://github.com/stakater/Reloader)
+    project can be used to watch for changes in an application ConfigMap,
+    and trigger a rolling upgrade of the associated Deployment whenever
+    ConfigMap contents have changed.
+
+  - **OPTION 4: FUTURE SUPPORT: Configure Secrets Provider to Send Restart Signal**
     In a future version of Secrets Provider, it will be possible to configure
     the configure the Secrets Provider to send a configurable restart signal
     (e.g. SIGKILL, SIGTERM, etc.) to the application process(es) after target


### PR DESCRIPTION
### Desired Outcome

Options for doing application container restart should include a mention of possibly using the Kubernetes Reloader project:
https://github.com/stakater/Reloader

### Implemented Changes

An option for doing application container restart using Kubernetes Reloader project is added.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
