### PR TITLE
Added automated release process to project pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.1] - 2022-04-01
+### Changed
+- Update to automated release process. [cyberark/secrets-provider-for-k8s#455](https://github.com/cyberark/secrets-provider-for-k8s/pull/455)
+
 ### Added
 - Secrets files are written in an atomic operation. [cyberark/secrets-provider-for-k8s#440](https://github.com/cyberark/secrets-provider-for-k8s/pull/440)
 - Secret files are deleted when secrets are removed from Conjur or access is revoked. Can be disabled with annotation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,9 +243,8 @@ follow the instructions in this section.
 
 ### Update the version, changelog, and notices
 1. Create a new branch for the version bump.
-1. Based on the unreleased content, determine the new version number.
+1. Based on the changelog content, determine the new version number.
 1. Update this version in the following files:
-    1. [Version file](pkg/secrets/version.go)
     1. [Chart version](helm/secrets-provider/Chart.yaml)
     1. [Default deployed version](helm/secrets-provider/values.yaml)
     1. [Helm unit test for chart defaults](helm/secrets-provider/tests/secrets_provider_test.yaml)
@@ -253,14 +252,6 @@ follow the instructions in this section.
 1. Commit these changes - `Bump version to x.y.z` is an acceptable commit
    message - and open a PR for review.
    
-### Add a git tag
-1. Once your changes have been reviewed and merged into main, tag the version
-   using `git tag -s v0.1.1`. Note this requires you to be able to sign releases.
-   Consult the [github documentation on signing commits](https://help.github.com/articles/signing-commits-with-gpg/)
-   on how to set this up. `vx.y.z` is an acceptable tag message.
-1. Push the tag: `git push vx.y.z` (or `git push origin vx.y.z` if you are working
-   from your local machine).
-
 ### Push Helm package
 1. Every build packages the Secrets Provider Helm chart for us. The package can be found under the 'Artifacts' tab of the Jenkins build and will resemble `secrets-provider-<version>.tgz`. 
 Navigate to the 'Artifacts' tab of the _tagged version_ build and save this file. You will need it for the next step.
@@ -269,11 +260,11 @@ Navigate to the 'Artifacts' tab of the _tagged version_ build and save this file
     1. Go to the `helm-charts` repo root folder and execute the `reindex.sh` script file located there.
     1. Create a PR with those changes.
     
-### Publish the git release
-1. In the GitHub UI, create a release from the new tag and copy the change log
-for the new version into the GitHub release description. The Jenkins pipeline 
-will auto-publish new images to DockerHub.
                                                             
+### Release and Promote
+1. Merging into main/master branches will automatically trigger a release. If successful, this release can be promoted at a later time.
+1. Jenkins build parameters can be utilized to promote a successful release or manually trigger aditional releases as needed.
+1. Reference the [internal automated release doc](https://github.com/conjurinc/docs/blob/master/reference/infrastructure/automated_releases.md#release-and-promotion-process) for releasing and promoting.
 ### Publish the Red Hat image
 1. Visit the [Red Hat project page](https://connect.redhat.com/project/4381831/view) once the images have been pushed 
 and manually choose to publish the latest release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ EXPOSE 8080
 
 COPY go.mod go.sum ./
 
+# Get upstream dependencies latest changes.
+RUN go get github.com/cyberark/conjur-api-go@latest && \
+    go get github.com/cyberark/conjur-authn-k8s-client@latest && \
+    go get github.com/cyberark/conjur-opentelemetry-tracer@latest
+
 # Add a layer of prefetched modules so the modules are already cached in case we rebuild
 RUN go mod download
 
@@ -34,6 +39,9 @@ RUN go mod download
 FROM secrets-provider-builder-base as secrets-provider-builder
 
 COPY . .
+
+# Update go.mod to include the upstream dependencies.
+RUN go mod tidy
 
 # this value is set in ./bin/build
 ARG TAG

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -23,8 +23,16 @@ RUN apk add -u curl \
 
 COPY go.mod go.sum /secrets-provider-for-k8s/
 
+# Get upstream dependencies latest changes.
+RUN go get github.com/cyberark/conjur-api-go@latest && \
+    go get github.com/cyberark/conjur-authn-k8s-client@latest && \
+    go get github.com/cyberark/conjur-opentelemetry-tracer@latest
+
 RUN go mod download
 
 COPY . .
+
+# Update go.mod to include the upstream dependencies.
+RUN go mod tidy
 
 ENTRYPOINT [ "go", "test", "-v", "-timeout", "3m" ]

--- a/bin/build
+++ b/bin/build
@@ -19,7 +19,9 @@ cd $(dirname $0)/..
 
 . bin/build_utils
 
-FULL_VERSION_TAG="$(full_version_tag)"
+# Version derived from CHANGLEOG and automated release library
+VERSION=$(<VERSION)
+FULL_VERSION_TAG="$VERSION-$(git_tag)"
 
 echo "---"
 

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -30,6 +30,17 @@ gen_versions() {
   done
 }
 
+function tag_and_push() {
+  local source="$1"
+  shift
+  local target="$1"
+  shift
+
+  echo "Tagging and pushing $target..."
+  docker tag "${source}" "${target}"
+  docker push "${target}"
+}
+
 function retrieve_cyberark_ca_cert() {
   # On CyberArk dev laptops, golang module dependencies are downloaded with a
   # corporate proxy in the middle. For these connections to succeed we need to

--- a/bin/publish
+++ b/bin/publish
@@ -2,45 +2,130 @@
 
 set -e
 
+# The following is used to:
+# Publish images on pre-release and tag as edge
+# Promote pre-releases to releases and tag as latest
+
 . bin/build_utils
 
-readonly VERSION="$(short_version_tag)"
-readonly FULL_VERSION_TAG="$(full_version_tag)"
+function print_help() {
+  echo "Build Usage: $0 --internal"
+  echo "Release Usage: $0 --edge"
+  echo "Promote Usage: $0 --promote --source <VERSION> --target <VERSION>"
+  echo " --internal: publish images to registry.tld"
+  echo " --edge: publish docker images to docker hub"
+  echo " --source <VERSION>: specify version number of local image"
+  echo " --target <VERSION>: specify version number of remote image"
+}
+
+# Fail if no arguments are given.
+if [[ $# -lt 1 ]]; then
+  print_help
+  exit 1
+fi
+
+PUBLISH_INTERNAL=false
+PUBLISH_EDGE=false
+PROMOTE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --internal)
+    PUBLISH_INTERNAL=true
+    ;;
+  --edge)
+    PUBLISH_EDGE=true
+    ;;
+  --promote)
+    PROMOTE=true
+    ;;
+  --source)
+    SOURCE_ARG="$2"
+    shift
+    ;;
+  --target)
+    TARGET_ARG="$2"
+    shift
+    ;;
+  --help)
+    print_help
+    exit 1
+    ;;
+  *)
+    echo "Unknown option: ${1}"
+    print_help
+    exit 1
+    ;;
+  esac
+  shift
+done
+
 readonly REDHAT_IMAGE="scan.connect.redhat.com/ospid-56594c20-22fc-4eeb-9c2e-402cf43bcb79/secrets-provider-for-k8s"
-
-readonly TAGS=(
-  "$VERSION"
-  "latest"
-)
-
+readonly REDHAT_LOCAL_IMAGE="secrets-provider-for-k8s-redhat"
 readonly IMAGE_NAME="secrets-provider-for-k8s"
-
 readonly REGISTRY='cyberark'
+# Version derived from CHANGLEOG and automated release library
+VERSION=$(<VERSION)
+readonly VERSION
+FULL_VERSION_TAG="$VERSION-$(git_tag)"
+readonly FULL_VERSION_TAG
 
-# if the tag matches the VERSION, push VERSION and latest releases
-# and x and x.y releases
-if [ "$GIT_DESCRIPTION" = "v${VERSION}" ]; then
-  echo "Revision $GIT_DESCRIPTION matches version $VERSION exactly. Pushing to Dockerhub..."
+if [[ ${PUBLISH_INTERNAL} = true ]]; then
+  echo "Publishing built images internally to registry.tld."
+  SOURCE_TAG=$FULL_VERSION_TAG
+  REMOTE_TAG=$VERSION
 
-  for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
+  tag_and_push "${IMAGE_NAME}:${SOURCE_TAG}" "registry.tld/${IMAGE_NAME}:${REMOTE_TAG}"
+  tag_and_push "${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "registry.tld/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}"
+fi
+
+if [[ ${PUBLISH_EDGE} = true ]]; then
+  echo "Performing edge release."
+  SOURCE_TAG=$FULL_VERSION_TAG
+  REMOTE_TAG=edge
+  readonly TAGS=(
+    "$VERSION"
+    "$REMOTE_TAG"
+  )
+
+  for tag in "${TAGS[@]}"; do
+    tag_and_push "$IMAGE_NAME:$SOURCE_TAG" "$REGISTRY/$IMAGE_NAME:$tag"
+  done
+fi
+
+if [[ ${PROMOTE} = true ]]; then
+  if [[ -z ${SOURCE_ARG:-} || -z ${TARGET_ARG:-} ]]; then
+  echo "When promoting, --source and --target flags are required."
+  print_help
+  exit 1
+  fi
+
+  # Update vars to utilize build_utils
+  SOURCE_TAG=$SOURCE_ARG
+  REMOTE_TAG=$TARGET_ARG
+
+  echo "Promoting image to $REMOTE_TAG"
+  readonly TAGS=(
+    "$REMOTE_TAG"
+    "latest"
+  )
+
+  for tag in "${TAGS[@]}" $(gen_versions "$REMOTE_TAG"); do
     echo "Tagging and pushing $REGISTRY/$IMAGE_NAME:$tag"
-
-    docker tag "$IMAGE_NAME:$FULL_VERSION_TAG" "$REGISTRY/$IMAGE_NAME:$tag"
-    docker push "$REGISTRY/$IMAGE_NAME:$tag"
+    tag_and_push "$IMAGE_NAME:$SOURCE_TAG" "$REGISTRY/$IMAGE_NAME:$tag"
   done
 
-  # Publish RedHat image to Internal Registry
-  docker tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" "$REGISTRY/secrets-provider-for-k8s-redhat:${VERSION}"
-  docker push "$REGISTRY/secrets-provider-for-k8s-redhat:${VERSION}"
+  # Publish RedHat image to docker hub
+  tag_and_push "${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "$REGISTRY/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}"
 
   # Publish only latest to Redhat Registries
   echo "Tagging and pushing ${REDHAT_IMAGE}"
-  docker tag "secrets-provider-for-k8s-redhat:${FULL_VERSION_TAG}" "${REDHAT_IMAGE}:${VERSION}"
+  echo docker tag "${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_IMAGE}:${REMOTE_TAG}"
 
   # Publish RedHat image to RedHat Registry
   if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
     # you can't push the same tag twice to redhat registry, so ignore errors
-    if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
+    if ! docker push "${REDHAT_IMAGE}:${REMOTE_TAG}"; then
       echo 'Red Hat push FAILED! (maybe the image was pushed already?)'
       exit 0
     fi
@@ -48,8 +133,5 @@ if [ "$GIT_DESCRIPTION" = "v${VERSION}" ]; then
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
-elif [ "$BRANCH_NAME" = "main" ]; then
-  echo "Successful Master build. Tagging and pushing $REGISTRY/$IMAGE_NAME:edge"
-  docker tag "$IMAGE_NAME:$FULL_VERSION_TAG" "$REGISTRY/$IMAGE_NAME:edge"
-  docker push "$REGISTRY/$IMAGE_NAME:edge"
+
 fi

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,6 @@ go 1.17
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/cyberark/conjur-api-go v0.8.1
-	github.com/cyberark/conjur-authn-k8s-client v0.23.0
-	github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-58
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
- Reconfigured bin/publish to perform releases and promotions
of contianer images based on optional flag parameters.

- Added additional functions in bin/build_utils for the automated releases.

- Maintained legacy bin/build_utils functions that are currently no longer in
use, but might provide useful in the future.

- Added submodule for cyberark/conjur-opentelemetry-tracer upstream dependency.

- Added submodule for cyberark/conjur-authn-k8s-client upstream dependency.

- Added submodule for cyberark/conjur-api-go upstream dependency.

- During a build, images get pushed inertnally to registry.tld. These
images allow for promotion at a later time if/when necessary.

### Desired Outcome

Add project to automated release process.

### Implemented Changes

- Version file is automatically generated from the CHANGELOG, this is utilized for automated
releases.

- Github pre-release are automatically generated with the option to promote said pre-release
to a GitHub release for customers.

- Docker Software Bill of Materials is generated on releases and is stored as an artifact. This can
be utilized to regenerate the go.mod file.

- Builds will tag and push images internally to registry.tld.

- Container images are tagged as edge for pre-releases.

- Images that are promoted (released) are tagged as latest. 

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
