### PR TITLE
Fix rotation tests on OpenShift

### DIFF
--- a/deploy/config/k8s/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/k8s/test-env-k8s-rotation.sh.yml
@@ -36,6 +36,18 @@ spec:
         name: test-app
         command: ["sleep"]
         args: ["infinity"]
+        livenessProbe:
+          exec:
+            command:
+            - /mounted/status/conjur-secrets-unchanged.sh
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: conjur-status
+          mountPath: /mounted/status
         env:
           - name: TEST_SECRET
             valueFrom:
@@ -57,17 +69,19 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: non-conjur-key
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+        imagePullPolicy: Always
+        name: cyberark-secrets-provider-for-k8s
         lifecycle:
           postStart:
             exec:
               command:
               - /usr/local/bin/conjur-secrets-provided.sh
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
-        imagePullPolicy: Always
-        name: cyberark-secrets-provider-for-k8s
         volumeMounts:
           - mountPath: /conjur/podinfo
             name: podinfo
+          - name: conjur-status
+            mountPath: /conjur/status
         env:
           - name: MY_POD_NAME
             valueFrom:
@@ -111,6 +125,9 @@ spec:
               fieldPath: metadata.annotations
             path: annotations
         name: podinfo
+      - name: conjur-status
+        emptyDir:
+          medium: Memory
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/config/openshift/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-k8s-rotation.sh.yml
@@ -35,6 +35,18 @@ spec:
         name: test-app
         command: ["sleep"]
         args: ["infinity"]
+        livenessProbe:
+          exec:
+            command:
+            - /mounted/status/conjur-secrets-unchanged.sh
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: conjur-status
+          mountPath: /mounted/status
         env:
           - name: TEST_SECRET
             valueFrom:
@@ -56,17 +68,19 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: non-conjur-key
+      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
+        imagePullPolicy: Always
+        name: cyberark-secrets-provider-for-k8s
         lifecycle:
           postStart:
             exec:
               command:
               - /usr/local/bin/conjur-secrets-provided.sh
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
-        imagePullPolicy: Always
-        name: cyberark-secrets-provider-for-k8s
         volumeMounts:
           - mountPath: /conjur/podinfo
             name: podinfo
+          - name: conjur-status
+            mountPath: /conjur/status
         env:
           - name: MY_POD_NAME
             valueFrom:
@@ -110,6 +124,9 @@ spec:
               fieldPath: metadata.annotations
             path: annotations
         name: podinfo
+      - name: conjur-status
+        emptyDir:
+          medium: Memory
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
@@ -36,6 +36,18 @@ spec:
         name: test-app
         command: ["sleep"]
         args: ["infinity"]
+        livenessProbe:
+          exec:
+            command:
+            - /mounted/status/conjur-secrets-unchanged.sh
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: conjur-status
+          mountPath: /mounted/status
         env:
           - name: TEST_SECRET
             valueFrom:
@@ -57,17 +69,19 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: non-conjur-key
+      - image: 'secrets-provider-for-k8s:latest'
+        imagePullPolicy: Never
+        name: cyberark-secrets-provider-for-k8s
         lifecycle:
           postStart:
             exec:
               command:
               - /usr/local/bin/conjur-secrets-provided.sh
-      - image: 'secrets-provider-for-k8s:latest'
-        imagePullPolicy: Never
-        name: cyberark-secrets-provider-for-k8s
         volumeMounts:
           - mountPath: /conjur/podinfo
             name: podinfo
+          - name: conjur-status
+            mountPath: /conjur/status
         env:
           - name: MY_POD_NAME
             valueFrom:
@@ -108,6 +122,9 @@ spec:
               fieldPath: metadata.annotations
             path: annotations
         name: podinfo
+      - name: conjur-status
+        emptyDir:
+          medium: Memory
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/test/test_cases/TEST_ID_29_k8s_secrets_rotation.sh
+++ b/deploy/test/test_cases/TEST_ID_29_k8s_secrets_rotation.sh
@@ -1,36 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-delete_test_secret() {
-  load_policy "conjur-delete-secret"
-}
-
-restore_test_secret() {
-  load_policy "conjur-secrets"
-}
-
-load_policy() {
-  filename=$1
-  set_namespace "$CONJUR_NAMESPACE_NAME"
-  configure_cli_pod
-
-  pushd "../../policy"
-    mkdir -p ./generated
-    ./templates/$filename.template.sh.yml > ./generated/$APP_NAMESPACE_NAME.$filename.yml
-  popd
-  
-  conjur_cli_pod=$(get_conjur_cli_pod_name)
-  $cli_with_timeout "exec $conjur_cli_pod -- rm -rf /policy"
-  $cli_with_timeout "cp ../../policy $conjur_cli_pod:/policy"
-
-  $cli_with_timeout "exec $(get_conjur_cli_pod_name) -- \
-    conjur policy load --delete root \"/policy/generated/$APP_NAMESPACE_NAME.$filename.yml\""
-
-  $cli_with_timeout "exec $conjur_cli_pod -- rm -rf ./policy"
-
-  set_namespace $APP_NAMESPACE_NAME
-}
-
 create_secret_access_role
 
 create_secret_access_role_binding
@@ -45,13 +15,10 @@ verify_secret_value_in_pod $pod_name1 TEST_SECRET supersecret
 set_conjur_secret secrets/test_secret secret2
 sleep 10
 
+echo "Verify pod $pod_name1 has environment variable 'TEST_SECRET' with value 'secret2'"
 verify_secret_value_in_pod $pod_name1 TEST_SECRET secret2
 
-delete_test_secret
-
-sleep 10
-
-verify_secret_value_in_pod $pod_name1 TEST_SECRET ""
-
-# Restore the test secret to reset the environment
-restore_test_secret
+# Note: We're not testing secrets deletion here like we do in TEST_ID_28_push_to_file_secrets_rotation. This is because removing the
+# secret values from K8s will cause the pod to fail on startup due to the missing secretKeyRefs. We would need another way to test this
+# other than checking that the environment variable is cleared. Being that rotation is mainly used with Push-to-File, it may not be
+# worth going through the effort to develop tests for this scenario.


### PR DESCRIPTION
### Implemented Changes

- Fixed integration test yaml that mistakenly had the postStart lifecycle hook in the app container instead of the secrets-provider container, and added livenessProbe to restart the app container when secrets change. This should fix testing reliability on OpenShift.

- Also removed the secret deletion portion of the rotation tests in k8s-secrets mode. This test was unreliable because the removal of the secret caused the app container to fail before starting. We would need another way to test this other than checking that the environment variable is cleared. Being that rotation is mainly used with Push-to-File, it may not be worth going through the effort to develop tests for this scenario.

### Connected Issue/Story

N/A

### Definition of Done

- [x] CI passes consistently (including OCP)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
