### PR TITLE
Check if VERSION file exists for build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -19,8 +19,9 @@ cd $(dirname $0)/..
 
 . bin/build_utils
 
-# Version derived from CHANGLEOG and automated release library
-VERSION=$(<VERSION)
+VERSION=unreleased
+# Version derived from CHANGELOG and automated release library
+[ -f VERSION ] && VERSION=$(<VERSION)
 FULL_VERSION_TAG="$VERSION-$(git_tag)"
 
 echo "---"


### PR DESCRIPTION
### Desired Outcome
Getting an error when building locally,
local builds should not require the VERSION file

### Implemented Changes

For local builds, check if the VERSION file exists, if not then 
make the version unreleased.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
