### PR TITLE
Check for CONTAINER_MODE environmental variable for rotation

### DIFF
--- a/cmd/secrets-provider/main.go
+++ b/cmd/secrets-provider/main.go
@@ -258,6 +258,8 @@ func getContainerMode() string {
 	containerMode := "init"
 	if mode, exists := annotationsMap[secretsConfigProvider.ContainerModeKey]; exists {
 		containerMode = mode
+	} else if mode = os.Getenv("CONTAINER_MODE"); mode == "sidecar" || mode == "application" {
+		containerMode = mode
 	}
 	return containerMode
 }

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -114,6 +114,7 @@ var validEnvVars = []string{
 	"RETRY_COUNT_LIMIT",
 	"JWT_TOKEN_PATH",
 	"REMOVE_DELETED_SECRETS",
+	"CONTAINER_MODE",
 }
 
 // ValidateAnnotations confirms that the provided annotations are properly
@@ -215,8 +216,7 @@ func ValidateSecretsProviderSettings(envAndAnnots map[string]string) ([]error, [
 
 	annotSecretsRefreshEnable := envAndAnnots[SecretsRefreshEnabledKey]
 	annotSecretsRefreshInterval := envAndAnnots[SecretsRefreshIntervalKey]
-	annotContainerMode := envAndAnnots[ContainerModeKey]
-	err = validRefreshInterval(annotSecretsRefreshInterval, annotSecretsRefreshEnable, annotContainerMode)
+	err = validRefreshInterval(annotSecretsRefreshInterval, annotSecretsRefreshEnable, envAndAnnots)
 	if err != nil {
 		errorList = append(errorList, err)
 	}
@@ -383,9 +383,16 @@ func validateStore(envStoreType string) (string, error) {
 	return storeType, err
 }
 
-func validRefreshInterval(intervalStr string, enableStr string, containerMode string) error {
+func validRefreshInterval(intervalStr string, enableStr string, envAndAnnots map[string]string) error {
 
 	var err error
+
+	containerMode := envAndAnnots[ContainerModeKey]
+	envContainerMode := envAndAnnots["CONTAINER_MODE"]
+	if containerMode == "" {
+		containerMode = envContainerMode
+	}
+
 	if intervalStr != "" || enableStr != "" {
 		if containerMode != "sidecar" {
 			return fmt.Errorf(messages.CSPFK051E, "Secrets refresh is enabled while container mode is set to", containerMode)

--- a/pkg/secrets/config/config_test.go
+++ b/pkg/secrets/config/config_test.go
@@ -354,6 +354,16 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 		assert: assertEmptyErrorList(),
 	},
 	{
+		description: "if refresh enable is true container mode set with env, no errors are returned",
+		envAndAnnots: map[string]string{
+			"MY_POD_NAMESPACE":       "test-namespace",
+			SecretsDestinationKey:    "file",
+			SecretsRefreshEnabledKey: "true",
+			"CONTAINER_MODE":         "sidecar",
+		},
+		assert: assertEmptyErrorList(),
+	},
+	{
 		description: "if refresh enable is false and interval not set, no errors are returned",
 		envAndAnnots: map[string]string{
 			"MY_POD_NAMESPACE":       "test-namespace",
@@ -408,6 +418,18 @@ var validateSecretsProviderSettingsTestCases = []validateSecretsProviderSettings
 			ContainerModeKey:          "init",
 		},
 		assert: assertErrorInList(fmt.Errorf(messages.CSPFK051E, "Secrets refresh is enabled while container mode is set to", "init")),
+	},
+	{
+		description: "if refresh interval is set and container mode set with env",
+		envAndAnnots: map[string]string{
+			"MY_POD_NAMESPACE":        "test-namespace",
+			SecretsRefreshIntervalKey: "5s",
+			ContainerModeKey:          "",
+			"CONTAINER_MODE":          "sidecar",
+			"SECRETS_DESTINATION":     "k8s_secrets",
+			"K8S_SECRETS":             "another-secret-1,another-secret-2",
+		},
+		assert:  assertEmptyErrorList(),
 	},
 }
 


### PR DESCRIPTION
### Desired Outcome

If using environmental variables to configure secrets provider and you add secrets rotation,
you should be able to set the container mode with environmental variable.

### Implemented Changes

Add a check for the CONTAINER_MODE environmental variable.
In main.go just added a check to read the environmental variable to keep the changes
to a minimum as these changes will be removed when we depreciate env variables.


### Connected Issue/Story

Resolves #N/A



### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
