### PR TITLE
Remove support for OCP v3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ so no flag is required.
 For example:
 
 - Deploy Conjur Open Source on GKE, run  `./bin/start --oss --gke`
-- Deploy Conjur Enterprise on Openshift, run  `./bin/start --dap --oc311`
+- Deploy Conjur Enterprise on Openshift, run  `./bin/start --dap --current`
 
 It is also possible to run a single test instead of the full suite. This can be done by running `./bin/start` with the
 flag `--test-prefix=<prefix>`. For example, running with the flag `--test-prefix=TEST_ID_18` will run only the test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,9 +202,6 @@ pipeline {
           steps {
             script {
               def tasks = [:]
-              tasks["Openshift v3.11, DAP"] = {
-                  sh "./bin/start --docker --dap --oc311"
-              }
               if ( params.TEST_OCP_OLDEST ) {
                 tasks["Openshift (Oldest), DAP"] = {
                   sh "./bin/start --docker --dap --oldest"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ __NOTE: If you are using the Secrets Provider "Push to file" mode, the
 
 - K8s 1.11+
 
-- Openshift 3.11, 4.5, 4.6, 4.7, and 4.8 _*(Conjur Enterprise only)*_
+- Openshift v4.6-v4.8 _*(Conjur Enterprise only)*_
 
 ## Using secrets-provider-for-k8s with Conjur Open Source 
 

--- a/bin/start
+++ b/bin/start
@@ -20,8 +20,6 @@ Usage: ./bin/start [options]
 
     --gke         Run the integration tests on GKE. By default the tests are run on GKE.
 
-    --oc311 Run the integration tests on Openshift v3.11. By default the tests are run on GKE.
-
     --oldest      Run the integration tests on the oldest running Openshift platform. By default the tests are run on GKE.
 
     --current     Run the integration tests on the currently supported Openshift platform. By default the tests are run on GKE.
@@ -54,7 +52,6 @@ while true ; do
     --oss ) CONJUR_DEPLOYMENT=oss ; shift ;;
     --dap ) CONJUR_DEPLOYMENT=dap ; shift ;;
     --gke ) SUMMON_ENV=gke ; shift ;;
-    --oc311 ) SUMMON_ENV=oc311 ; shift ;;
     --oldest ) SUMMON_ENV=oldest ; shift ;;
     --current ) SUMMON_ENV=current ; shift ;;
     --next ) SUMMON_ENV=next ; shift ;;

--- a/deploy/summon/secrets.yml
+++ b/deploy/summon/secrets.yml
@@ -1,6 +1,6 @@
 common:
   KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
 
   CONJUR_ACCOUNT: my-account
   CONJUR_ADMIN_PASSWORD: ADmin123!!!!
@@ -27,19 +27,6 @@ gke:
   DOCKER_REGISTRY_PATH: us.gcr.io/refreshing-mark-284016
   PULL_DOCKER_REGISTRY_URL: us.gcr.io
   PULL_DOCKER_REGISTRY_PATH: us.gcr.io/refreshing-mark-284016
-
-oc311:
-  OPENSHIFT_VERSION: "3.11"
-  OPENSHIFT_URL: !var ci/openshift/3.11/hostname
-  OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
-
-  PLATFORM: openshift
-  TEST_PLATFORM: openshift311
-  DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
-  DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
-  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
-  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
 
 oldest:
   OPENSHIFT_VERSION: !var ci/openshift/oldest/version
@@ -70,7 +57,6 @@ current:
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
 
 next:
-  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.2/openshift-client-linux.tar.gz
   OPENSHIFT_VERSION: !var ci/openshift/next/version
   OPENSHIFT_URL: !var ci/openshift/next/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/next/username

--- a/deploy/test/Dockerfile
+++ b/deploy/test/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis
 # Install OpenShift oc CLI
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
-    wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
+    wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz} && \
     tar xvf oc.tar.gz -C ocbin && \
     cp "$(find ./ocbin -name 'oc' -type f | tail -1)"  /usr/local/bin/oc  && \
     rm -rf ocbin oc.tar.gz


### PR DESCRIPTION
### Desired Outcome

Remove support for testing against OCP v3.11 as it is now EoL and we are discontinuing support.

### Implemented Changes

All references to v3.11 are removed including documentation and test tooling.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: ONYX-22651
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
