### PR TITLE
Bump version to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.4.3] - 2022-06-14
+## [1.4.3] - 2022-07-07
+### Removed
+- Support for OpenShift v3.11 is officially removed as of this release.
+  [cyberark/secrets-provider-for-k8s#474](https://github.com/cyberark/secrets-provider-for-k8s/pull/474)
+
 ### Security
-- Add replace statements to go.mod to prune vulnerable dependency versions from the dependency tree
+- Add replace statements to go.mod to prune vulnerable dependency versions from the dependency tree.
   [cyberark/secrets-provider-for-k8s#470](https://github.com/cyberark/secrets-provider-for-k8s/pull/470)
   [cyberark/secrets-provider-for-k8s#471](https://github.com/cyberark/secrets-provider-for-k8s/pull/471)
-- Update the Red Hat ubi image in Dockerfile 
+- Update the Red Hat ubi image in Dockerfile.
   [cyberark/secrets-provider-for-k8s#469](https://github.com/cyberark/secrets-provider-for-k8s/pull/469)
 
 ## [1.4.2] - 2022-05-03
 ### Changed
 - Updated dependencies in go.mod (github.com/stretchr/testify -> v1.7.2, go.opentelemetry.io/otel -> 1.7.0,
-  gopkg.in/yaml.v3 -> v3.0.1, k8s.io/api -> 0.24.1, k8s.io/apimachinery -> 0.24.1, k8s.io/client-go -> 0.24.1)
+  gopkg.in/yaml.v3 -> v3.0.1, k8s.io/api -> 0.24.1, k8s.io/apimachinery -> 0.24.1, k8s.io/client-go -> 0.24.1).
   [cyberark/secrets-provider-for-k8s#468](https://github.com/cyberark/secrets-provider-for-k8s/pull/468)
 
 ## [1.4.1] - 2022-04-01
@@ -227,7 +231,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.3.0...v1.4.0

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.1'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.3'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.4.1
+version: 1.4.3
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.1
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.3
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.4.1
+  tag: 1.4.3
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.4.1"
+var Version = "1.4.3"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Bump version to 1.4.3 - include yaml.v3 security fixes, among others, and OCP 3.11 support removal.

### Implemented Changes

- Add OCP 3.11 support removal to Changelog
- Update Helm chart version and default SP version deployed
- Update version-based test cases

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
