### PR TITLE
Fix for error copying conjur-secrets-unchanged.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add replace statements to go.mod to prune vulnerable dependency versions from the dependency tree.
   [cyberark/secrets-provider-for-k8s#478](https://github.com/cyberark/secrets-provider-for-k8s/pull/478)
 
+### Fixed
+- Fixes the following error seen on boot up when the status volumemount is not added
+  "open /conjur/status/conjur-secrets-unchanged.sh: no such file or directory"
+  [cyberark/secrets-provider-for-k8s#479](https://github.com/cyberark/secrets-provider-for-k8s/pull/479)
+
 ## [1.4.3] - 2022-07-07
 ### Removed
 - Support for OpenShift v3.11 is officially removed as of this release.

--- a/pkg/secrets/provider_status_test.go
+++ b/pkg/secrets/provider_status_test.go
@@ -42,21 +42,32 @@ func testOpen(injectErr error) openFunc {
 	}
 }
 
+func testMkdirAll(injectErr error) mkdirAllFunc {
+	return func(path string, mode os.FileMode) error {
+		if injectErr != nil {
+			return injectErr
+		}
+		return stdOSFuncs.mkdirAll(path, mode)
+	}
+}
+
 // injectErrs defines a set of errors that should be injected for a given
 // test case.
 type injectErrs struct {
 	chmodErr  error
 	createErr error
 	openErr   error
+	mkDirErr  error
 }
 
 // testOSFuncs generates a set of OS functions for testing, each of which
 // support an option to return an "injected" error.
 func testOSFuncs(inject injectErrs) osFuncs {
 	return osFuncs{
-		chmod:  testChmod(inject.chmodErr),
-		create: testCreate(inject.createErr),
-		open:   testOpen(inject.openErr),
+		chmod:    testChmod(inject.chmodErr),
+		create:   testCreate(inject.createErr),
+		open:     testOpen(inject.openErr),
+		mkdirAll: testMkdirAll(inject.mkDirErr),
 	}
 }
 


### PR DESCRIPTION
### Desired Outcome

With the addition of sentinel files, sometimes the is an error copying the conjur-secrets-unchanged.sh 
script on MacOS. The workaround is to add the /conjur/status volume mount, but that 
should not be required. 

### Implemented Changes

Added creating the /conjur/secrets directory in case it doesn't exist from the mounted volumes.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23697](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23697)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
