### PR TITLE
Update the sample manifests to use generic naming

### DIFF
--- a/assets/jwt-k8s-rotation.yaml
+++ b/assets/jwt-k8s-rotation.yaml
@@ -5,20 +5,18 @@ metadata:
     app: test-app
   name: test-app
   namespace: test-app-namespace
-template:
- metadata:
-   annotations:
-     conjur.org/container-mode: sidecar
-     conjur.org/secrets-refresh-interval: 10s
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: test-app
-  replicas: 1
   template:
     metadata:
       labels:
         app: test-app
+      annotations:
+        conjur.org/container-mode: sidecar
+        conjur.org/secrets-refresh-interval: 10s
     spec:
       serviceAccountName: test-app-sa
       containers:
@@ -38,10 +36,12 @@ spec:
                 secretKeyRef:
                   name: db-credentials
                   key: password
-        - image: cyberark/secrets-provider-for-k8s
+        - image: 'cyberark/secrets-provider-for-k8s:latest'
           imagePullPolicy: Always
           name: cyberark-secrets-provider-for-k8s
           volumeMounts:
+          - name: conjur-status
+            mountPath: /conjur/status
           - name: jwt-token
             mountPath: /var/run/secrets/tokens
           - mountPath: /run/conjur
@@ -67,25 +67,27 @@ spec:
             - configMapRef:
                 name: conjur-connect
       volumes:
-      - name: jwt-token
-        projected:
-          sources:
-            - serviceAccountToken:
-                path: jwt
-                expirationSeconds: 6000
-                audience: https://conjur.host.name/
-      - emptyDir:
-          medium: Memory
-        name: conjur-access-token
-      - emptyDir:
-          medium: Memory
-        name: conjur-certs
-      - downwardAPI:
-          defaultMode: 420
-          items:
-          - fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.annotations
-            path: annotations
-        name: podinfo
-
+        - name: conjur-status
+          emptyDir:
+            medium: Memory
+        - name: jwt-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: jwt
+                  expirationSeconds: 6000
+                  audience: conjur
+        - emptyDir:
+            medium: Memory
+          name: conjur-access-token
+        - emptyDir:
+            medium: Memory
+          name: conjur-certs
+        - downwardAPI:
+            defaultMode: 420
+            items:
+            - fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.annotations
+              path: annotations
+          name: podinfo

--- a/assets/jwt-k8s.yaml
+++ b/assets/jwt-k8s.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+  namespace: test-app-namespace
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      serviceAccountName: test-app-sa
+      containers:
+        - name: test-app
+          image: <APPLICATION_IMAGE>
+          imagePullPolicy: <PULL_POLICY>
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: password
+      initContainers:
+      - image: 'cyberark/secrets-provider-for-k8s:latest'
+        imagePullPolicy: Always
+        name: cyberark-secrets-provider-for-k8s
+        volumeMounts:
+        - name: conjur-status
+          mountPath: /conjur/status
+        - name: jwt-token
+          mountPath: /var/run/secrets/tokens
+        env:
+          - name: JWT_TOKEN_PATH
+            value: /var/run/secrets/tokens/jwt
+          - name: CONTAINER_MODE
+            value: init
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_SECRETS
+            value: db-credentials
+          - name: SECRETS_DESTINATION
+            value: k8s_secrets
+        envFrom:
+          - configMapRef:
+              name: conjur-connect
+      volumes:
+      - name: conjur-status
+        emptyDir:
+          medium: Memory
+      - name: jwt-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: jwt
+                expirationSeconds: 6000
+                audience: conjur

--- a/assets/jwt-ptf-rotation.yaml
+++ b/assets/jwt-ptf-rotation.yaml
@@ -19,14 +19,13 @@ spec:
         conjur.org/secrets-destination: file
         conjur.org/jwt-token-path: /var/run/secrets/tokens/jwt
         conjur.org/conjur-secrets.test-app: |
-          - test-secrets-provider-p2f-jwt-app-db/url
-          - test-secrets-provider-p2f-jwt-app-db/username
-          - test-secrets-provider-p2f-jwt-app-db/password
+          - admin-username: <path to secret in Conjur Cloud>
+          - admin-password: <path to secret in Conjur Cloud>
         conjur.org/secret-file-path.test-app: "./credentials.yaml"
         conjur.org/secret-file-format.test-app: "yaml"
         conjur.org/secrets-refresh-interval: 10s
     spec:
-      serviceAccountName: test-app-secrets-provider-p2f-jwt
+      serviceAccountName: test-app-sa
       containers:
       - name: test-app
         image: nginx
@@ -38,10 +37,12 @@ spec:
         image: 'cyberark/secrets-provider-for-k8s:latest'
         imagePullPolicy: Always
         volumeMounts:
+        - name: conjur-status
+          mountPath: /conjur/status
         - name: podinfo
           mountPath: /conjur/podinfo
         - name: conjur-secrets
-          mountPath: /conjur/secrets
+          mountPath: /conjur/
         - name: jwt-token
           mountPath: /var/run/secrets/tokens
         env:
@@ -53,6 +54,9 @@ spec:
           - configMapRef:
               name: conjur-connect
       volumes:
+        - name: conjur-status
+          emptyDir:
+            medium: Memory
         - name: podinfo
           downwardAPI:
             items:
@@ -68,4 +72,4 @@ spec:
               - serviceAccountToken:
                   path: jwt
                   expirationSeconds: 6000
-                  audience: https://conjur.host.name/
+                  audience: conjur

--- a/assets/jwt-ptf.yaml
+++ b/assets/jwt-ptf.yaml
@@ -19,13 +19,12 @@ spec:
         conjur.org/secrets-destination: file
         conjur.org/jwt-token-path: /var/run/secrets/tokens/jwt
         conjur.org/conjur-secrets.test-app: |
-          - test-secrets-provider-p2f-jwt-app-db/url
-          - test-secrets-provider-p2f-jwt-app-db/username
-          - test-secrets-provider-p2f-jwt-app-db/password
+          - admin-username: <path to secret in Conjur Cloud>
+          - admin-password: <path to secret in Conjur Cloud>
         conjur.org/secret-file-path.test-app: "./credentials.yaml"
         conjur.org/secret-file-format.test-app: "yaml"
     spec:
-      serviceAccountName: test-app-secrets-provider-p2f-jwt
+      serviceAccountName: test-app-sa
       containers:
       - name: test-app
         image: nginx
@@ -38,10 +37,12 @@ spec:
         image: 'cyberark/secrets-provider-for-k8s:latest'
         imagePullPolicy: Always
         volumeMounts:
+        - name: conjur-status
+          mountPath: /conjur/status
         - name: podinfo
           mountPath: /conjur/podinfo
         - name: conjur-secrets
-          mountPath: /conjur/secrets
+          mountPath: /conjur/
         - name: jwt-token
           mountPath: /var/run/secrets/tokens
         env:
@@ -53,6 +54,9 @@ spec:
           - configMapRef:
               name: conjur-connect
       volumes:
+        - name: conjur-status
+          emptyDir:
+            medium: Memory
         - name: podinfo
           downwardAPI:
             items:
@@ -68,5 +72,4 @@ spec:
               - serviceAccountToken:
                   path: jwt
                   expirationSeconds: 6000
-                  audience: https://conjur.host.name/
-
+                  audience: conjur

--- a/assets/k8s-rotation.yaml
+++ b/assets/k8s-rotation.yaml
@@ -2,13 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: test-app-secrets-provider-k8s
-  name: test-app-secrets-provider-k8s
+    app: test-app
+  name: test-app
   namespace: test-app-namespace
 spec:
   selector:
     matchLabels:
-      app: test-app-secrets-provider-k8s
+      app: test-app
   replicas: 1
   template:
     metadata:
@@ -16,7 +16,7 @@ spec:
         conjur.org/secrets-refresh-enabled: "true"
         conjur.org/secrets-refresh-interval: 10s
       labels:
-        app: test-app-secrets-provider-k8s
+        app: test-app
     spec:
       serviceAccountName: test-app-sa
       containers:
@@ -40,7 +40,7 @@ spec:
         name: cyberark-secrets-provider-for-k8s
         env:
           - name: CONJUR_AUTHN_LOGIN
-            value: host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-k8s
+            value: host/conjur/authn-k8s/my-authenticator-id/apps/test-app
           - name: CONTAINER_MODE
             value: sidecar
           - name: MY_POD_NAME

--- a/assets/k8s-secrets.yaml
+++ b/assets/k8s-secrets.yaml
@@ -2,20 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: test-app-secrets-provider-k8s
-  name: test-app-secrets-provider-k8s
+    app: test-app
+  name: test-app
   namespace: test-app-namespace
 spec:
   selector:
     matchLabels:
-      app: test-app-secrets-provider-k8s
+      app: test-app
   replicas: 1
   template:
     metadata:
       labels:
-        app: test-app-secrets-provider-k8s
+        app: test-app
     spec:
-      serviceAccountName: test-app-secrets-provider-k8s
+      serviceAccountName: test-app-sa
       containers:
       - name: test-app
         image: ubuntu:latest
@@ -38,7 +38,7 @@ spec:
         name: cyberark-secrets-provider-for-k8s
         env:
           - name: CONJUR_AUTHN_LOGIN
-            value: host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-k8s
+            value: host/conjur/authn-k8s/my-authenticator-id/apps/test-app
           - name: CONTAINER_MODE
             value: init
           - name: MY_POD_NAME

--- a/assets/p2f-rotation.yaml
+++ b/assets/p2f-rotation.yaml
@@ -2,20 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: test-app-secrets-provider-p2f
-  name: test-app-secrets-provider-p2f
-  namespace: app-test
+    app: test-app
+  name: test-app
+  namespace: test-app-namespace
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app-secrets-provider-p2f
+      app: test-app
   template:
     metadata:
       labels:
-        app: test-app-secrets-provider-p2f
+        app: test-app
       annotations:
-        conjur.org/authn-identity: host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-p2f
+        conjur.org/authn-identity: host/conjur/authn-k8s/my-authenticator-id/apps/test-app
         conjur.org/container-mode: sidecar
         conjur.org/secrets-destination: file
         conjur.org/conjur-secrets.test-app: |
@@ -27,7 +27,7 @@ spec:
         conjur.org/secrets-refresh-enabled: "true"
         conjur.org/secrets-refresh-interval: 10m
     spec:
-      serviceAccountName: test-app-secrets-provider-p2f
+      serviceAccountName: test-app-sa
       containers:
         - name: test-app
           image: ubuntu:latest

--- a/assets/push-to-file.yaml
+++ b/assets/push-to-file.yaml
@@ -2,20 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: test-app-secrets-provider-p2f
-  name: test-app-secrets-provider-p2f
-  namespace: app-test
+    app: test-app
+  name: test-app
+  namespace: test-app-namespace
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app-secrets-provider-p2f
+      app: test-app
   template:
     metadata:
       labels:
-        app: test-app-secrets-provider-p2f
+        app: test-app
       annotations:
-        conjur.org/authn-identity: host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-p2f
+        conjur.org/authn-identity: host/conjur/authn-k8s/my-authenticator-id/apps/test-app
         conjur.org/container-mode: init
         conjur.org/secrets-destination: file
         conjur.org/conjur-secrets.test-app: |
@@ -25,7 +25,7 @@ spec:
         conjur.org/secret-file-path.test-app: "./application.yaml"
         conjur.org/secret-file-format.test-app: "yaml"
     spec:
-      serviceAccountName: test-app-secrets-provider-p2f
+      serviceAccountName: test-app-sa
       containers:
         - name: test-app
           image: ubuntu:latest


### PR DESCRIPTION
### Desired Outcome

The sample manifests should have the same naming as the docs to
minimize the manual changes that are done to the manifests when updating the docs.

### Implemented Changes

Updated the naming of the manifests so they can be copied right into the docs.
Added the JWT manifests that were used in the docs. 

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23699](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23699)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
