### PR TITLE
Update the docs for sentinel files securityContext

### DIFF
--- a/ROTATION.md
+++ b/ROTATION.md
@@ -131,7 +131,8 @@ Modify the Kubernetes manifest
 
 Prerequisites for using sentinel files:
 
-Requires secrets-provider-for-k8s v1.4.1 or later.
+Requires secrets-provider-for-k8s v1.4.1 or later.<br>
+Requires a shared volume that both the application and Secrets Provider can read and write to.
 
 Secrets Provider allows for its status to be monitored through the creation of a couple of empty sentinel files:
 `CONJUR_SECRETS_PROVIDED` and `CONJUR_SECRETS_UPDATED`. The first file is created when the SP has completed its first
@@ -188,6 +189,15 @@ This will cause the application to be restarted after there secrets have been up
           timeoutSeconds: 1
 ```
 
+By default, the Secrets Provider container runs using a default username `secrets-provider`,
+user ID `777`, and group ID `777`. For the application to delete the sentinel files the app and
+the Secrets provider should run as the same UID. For example the below securityContext 
+can be added to both the Secrets Provider and the Application, replacing 9999 with your desired value.
+
+```
+        securityContext:
+          runAsUser: 9999
+```
 
 ## Reference Table of Configuration Annotations
 


### PR DESCRIPTION
### Desired Outcome

The sentinel file documentation should describe how to modify the manifest
to run the app and secrets provider at the same user id so the app can delete the 
sentinel files.

### Implemented Changes

Update the sentinel file documentation,

### Connected Issue/Story


CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
