### PR TITLE
Update OpenShift RBAC object apiVersions, Bump version to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,7 +245,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.4...HEAD
+[1.4.4]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.0...v1.4.1

--- a/deploy/config/openshift/app-conjur-authenticator-role-binding.sh.yml
+++ b/deploy/config/openshift/app-conjur-authenticator-role-binding.sh.yml
@@ -4,7 +4,7 @@ set -euo pipefail
 cat << EOL
 ---
 kind: RoleBinding
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: app-conjur-authenticator-role-binding-${CONJUR_NAMESPACE_NAME}
   namespace: ${APP_NAMESPACE_NAME}
@@ -13,6 +13,7 @@ subjects:
     name: conjur-cluster
     namespace: ${CONJUR_NAMESPACE_NAME}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: conjur-authenticator-${CONJUR_NAMESPACE_NAME}
 EOL

--- a/deploy/config/openshift/secrets-access-role-binding.sh.yml
+++ b/deploy/config/openshift/secrets-access-role-binding.sh.yml
@@ -8,7 +8,7 @@ kind: ServiceAccount
 metadata:
   name: ${APP_NAMESPACE_NAME}-sa
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: ${APP_NAMESPACE_NAME}

--- a/deploy/config/openshift/secrets-access-role.sh.yml
+++ b/deploy/config/openshift/secrets-access-role.sh.yml
@@ -6,11 +6,12 @@ SECRET_CLUSTER_ROLE_VERBS_VALUE=${SECRET_CLUSTER_ROLE_VERBS_VALUE:-"[ \"get\", \
 
 cat << EOL
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: secrets-access-${UNIQUE_TEST_ID}
 rules:
-  - resources: ["secrets"]
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
     verbs: ${SECRET_CLUSTER_ROLE_VERBS_VALUE}
 EOL

--- a/deploy/config/openshift/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-k8s-rotation.sh.yml
@@ -5,7 +5,7 @@ CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_
 
 cat << EOL
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/deploy/config/openshift/test-env-p2f-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-p2f-rotation.sh.yml
@@ -5,7 +5,7 @@ CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_
 
 cat << EOL
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/deploy/config/openshift/test-env-push-to-file.sh.yml
+++ b/deploy/config/openshift/test-env-push-to-file.sh.yml
@@ -5,7 +5,7 @@ CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_
 
 cat << EOL
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -13,7 +13,7 @@ CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_
 
 cat << EOL
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/deploy/test/config/openshift/helm-app.yaml
+++ b/deploy/test/config/openshift/helm-app.yaml
@@ -1,6 +1,6 @@
 # This app is created to run end-to-end tests with the Secrets Provider Job to ensure the updated K8s Secret appear as
 # environment variables
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.3'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.4'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.4.3
+version: 1.4.4
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.3
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.4
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.4.3
+  tag: 1.4.4
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.4.3"
+var Version = "1.4.4"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

**Depends on [kubernetes-conjur-deploy#180](https://github.com/cyberark/kubernetes-conjur-deploy/pull/180)**

A deprecation in OpenShift has starting causing failures in Jenkins:

```
Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "authorization.openshift.io/v1" for your resource
```

### Implemented Changes

Non-groupfied OpenShift resources have been groupfied.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-24270](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-24270)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
