### PR TITLE
Fix flaky integration test

### DIFF
--- a/deploy/dev/reload.sh
+++ b/deploy/dev/reload.sh
@@ -36,7 +36,7 @@ main() {
     fi
 
     conjur_pod_name="$(get_pod_name "$CONJUR_NAMESPACE_NAME" "$selector")"
-    ssl_cert=$($cli_with_timeout "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME cat $cert_location")
+    ssl_cert=$($cli_with_timeout "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME -- cat $cert_location")
 
     export CONJUR_SSL_CERTIFICATE=$ssl_cert
 

--- a/deploy/run_with_summon.sh
+++ b/deploy/run_with_summon.sh
@@ -67,7 +67,7 @@ if [ "$CONJUR_DEPLOYMENT" = "oss" ]; then
     cert_location="/root/conjur-${CONJUR_ACCOUNT}.pem"
 fi
 conjur_pod_name="$(get_pod_name "$CONJUR_NAMESPACE_NAME" "$selector")"
-ssl_cert=$($cli_with_timeout "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME cat $cert_location")
+ssl_cert=$($cli_with_timeout "exec ${conjur_pod_name} --namespace $CONJUR_NAMESPACE_NAME -- cat $cert_location")
 
 export CONJUR_SSL_CERTIFICATE=$ssl_cert
 

--- a/deploy/test/test_cases/TEST_ID_26_helm_override_default_retry_successful.sh
+++ b/deploy/test/test_cases/TEST_ID_26_helm_override_default_retry_successful.sh
@@ -20,13 +20,13 @@ popd
 pod_name="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-helm')"
 
 # Find initial authentication error that should trigger the retry
-$cli_with_timeout "logs $pod_name | grep 'CSPFK010E Failed to authenticate'" | head -1
+$cli_with_timeout "logs $pod_name | grep 'CSPFK010E Failed to authenticate'"
 failure_time=$($cli_without_timeout logs $pod_name | grep 'CSPFK010E Failed to authenticate' | head -1 | awk '{ print $3 }' | awk -F: '{ print ($1 * 3600) + ($2 * 60) + int($3) }')
 
 
 # Validate that the Secrets Provider retry mechanism takes user input of RETRY_INTERVAL_SEC of 5 and RETRY_COUNT_LIMIT of 2
 echo "Expecting Secrets Provider retry configurations to take their defaults of RETRY_INTERVAL_SEC of 5 and RETRY_COUNT_LIMIT of 2"
-$cli_with_timeout "logs $pod_name | grep 'CSPFK010I Updating Kubernetes Secrets: 1 retries out of $RETRY_COUNT_LIMIT'" | head -1
+$cli_with_timeout "logs $pod_name | grep 'CSPFK010I Updating Kubernetes Secrets: 1 retries out of $RETRY_COUNT_LIMIT'"
 retry_time=$($cli_without_timeout logs $pod_name | grep "CSPFK010I Updating Kubernetes Secrets: 1 retries out of $RETRY_COUNT_LIMIT" | head -1 | awk '{ print $3 }' | awk -F: '{ print ($1 * 3600) + ($2 * 60) + int($3) }')
 
 duration=$(( retry_time - failure_time ))


### PR DESCRIPTION
### Desired Outcome

Fix flaky tests as seen in Jenkins runs [1056](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secrets-provider-for-k8s/detail/main/1056/pipeline/167/) and [1047](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secrets-provider-for-k8s/detail/main/1047/pipeline/154/).

Special thanks to @ismarc for help diagnosing this issue.

### Implemented Changes

Removed `| head -1` portion of `cli_with_timeout` command in TEST_ID_26_helm_override_default_retry_successful.sh. This is not necessary because we're not consuming the value at that point, but rather waiting for the value to appear in the logs. It was causing the command to randomly fail when the value wasn't yet in the logs.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-26380](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26380)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
