### PR TITLE
Bump version in changelog so that its higher then the previous promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.6] - 2022-12-02
+
 ## [1.4.5] - 2022-09-26
 ### Changed
 - Updated Go to 1.19


### PR DESCRIPTION
Desired Outcome
The latest version in the changelog has to be higher then the latest promotion in jenkins or it will cause the Release builds to fail. This is currently causing the OCP_NEXT pipeline to fail when testing secrets-provider.

Implemented Changes
Added new version in the changelog file.