### PR TITLE
Use optional errors for kubeclient permissions

### DIFF
--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
@@ -44,12 +44,12 @@ func (m testMocks) setPermissions(denyConjurRetrieve, denyK8sRetrieve,
 		m.conjurClient.ErrOnExecute = errors.New("custom error")
 	}
 	if denyK8sRetrieve {
-		m.kubeClient.CanRetrieve = false
+		m.kubeClient.ErrOnRetrieve = errors.New("custom error")
 	}
 	if denyK8sUpdate {
-		m.kubeClient.CanUpdate = false
+		m.kubeClient.ErrOnUpdate = errors.New("custom error")
 	} else {
-		m.kubeClient.CanUpdate = true
+		m.kubeClient.ErrOnUpdate = nil
 	}
 }
 


### PR DESCRIPTION
### Desired Outcome
Address TODO in k8s secrets client tests

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
