### PR TITLE
Fix false positive unit test stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,6 @@ COPY . .
 # Build debug flavor without compilation optimizations using "all=-N -l"
 RUN go build -a -installsuffix cgo -gcflags="all=-N -l" -o secrets-provider ./cmd/secrets-provider
 
-# =================== BUSYBOX LAYER ===================
-# this layer is used to get binaries into the main container
-FROM busybox
-
 # =================== BASE MAIN CONTAINER ===================
 # this layer is used to prepare a common layer for both debug and release containers
 FROM alpine:3.14 as secrets-provider-base
@@ -72,16 +68,6 @@ MAINTAINER CyberArk Software Ltd.
 # Ensure openssl development libraries are always up to date
 RUN apk add --no-cache openssl-dev
 
-# copy a few commands from busybox
-COPY --from=busybox /bin/tar /bin/tar
-COPY --from=busybox /bin/sleep /bin/sleep
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/ls /bin/ls
-COPY --from=busybox /bin/id /bin/id
-COPY --from=busybox /bin/whoami /bin/whoami
-COPY --from=busybox /bin/mkdir /bin/mkdir
-COPY --from=busybox /bin/chmod /bin/chmod
-COPY --from=busybox /bin/cat /bin/cat
 COPY bin/run-time-scripts /usr/local/bin/
 
 RUN apk add -u shadow libc6-compat && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,13 +167,16 @@ pipeline {
         stage('Run Unit Tests') {
           steps {
             sh './bin/test_unit'
-
-            junit 'junit.xml'
-            cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, lineCoverageTargets: '70, 0, 0', methodCoverageTargets: '70, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-            ccCoverage("gocov", "--prefix github.com/cyberark/secrets-provider-for-k8s")
+          }
+          post {
+            always {
+              sh './bin/coverage'
+              junit 'junit.xml'
+              cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, lineCoverageTargets: '70, 0, 0', methodCoverageTargets: '70, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+              ccCoverage("gocov", "--prefix github.com/cyberark/secrets-provider-for-k8s")
+            }
           }
         }
-        
         
         stage ("DAP Integration Tests on GKE") {
           steps {

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+junit_output_file="./junit.output"
+. bin/build_utils
+
+function main() {
+  build_docker_junit_image
+  run_junit_report
+}
+
+function build_docker_junit_image() {
+  rm -f junit.xml
+  echo "Building junit image..."
+  docker build -f Dockerfile.junit -t secrets-provider-for-k8s-junit:latest .
+}
+
+function run_junit_report() {
+  echo "Creating junit report and coverage output XML"
+  docker run --rm \
+    -v $PWD/:/test \
+    secrets-provider-for-k8s-junit:latest \
+    bash -exc "
+      cat ./junit.output | go-junit-report > ./junit.xml ;
+      gocov convert ./c.out | gocov-xml > ./coverage.xml
+    "
+}
+
+main

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -9,8 +9,6 @@ function main() {
   retrieve_cyberark_ca_cert
   build_docker_ut_image
   run_unit_tests
-  build_docker_junit_image
-  run_junit_report
 }
 
 function build_docker_ut_image() {
@@ -20,7 +18,6 @@ function build_docker_ut_image() {
 
 function run_unit_tests() {
   echo "Running unit tests..."
-  set +e
   docker run --rm -t \
              --volume "$PWD"/:/secrets-provider-for-k8s/test/ \
              secrets-provider-for-k8s-test-runner:latest \
@@ -29,24 +26,6 @@ function run_unit_tests() {
              ./pkg/... \
              | tee -a "$junit_output_file"
   echo "Unit test exit status: $?"
-}
-
-function build_docker_junit_image() {
-  set -e
-  rm -f junit.xml
-  echo "Building junit image..."
-  docker build -f Dockerfile.junit -t secrets-provider-for-k8s-junit:latest .
-}
-
-function run_junit_report() {
-  echo "Creating junit report and coverage output XML"
-  docker run --rm \
-    -v $PWD/:/test \
-    secrets-provider-for-k8s-junit:latest \
-    bash -exc "
-      cat ./junit.output | go-junit-report > ./junit.xml ;
-      gocov convert ./c.out | gocov-xml > ./coverage.xml
-    "
 }
 
 main


### PR DESCRIPTION
### Desired Outcome

Several of our CI pipelines follow [this pattern](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/bin/test_unit#L31) where the script that runs unit tests sets +e to prevent unit test failure from stopping the script from running. I believe this was done to ensure that the junit tests would run even if the tests failed, but it's having the unfortunate side effect of showing the unit testing phase as green in Jenkins when a unit test fails, making it a bit unclear what's going on.

### Implemented Changes

Break the junit logic into a separate script that can be run independently from the unit tests in a "post-always" block in the Jenkinsfile and return the error code when unit test(s) fail.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
