### PR TITLE
Enable SP to retrieve and provide German umlaut chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] - 2023-02-13
+
+### Added
+- Adds support for binary secret values and values with special characters.
+  [cyberark/secrets-provider-for-k8s#500](https://github.com/cyberark/secrets-provider-for-k8s/pull/500)
+
 ## [1.4.6] - 2023-01-26
 
 ### Security

--- a/deploy/config/k8s/k8s-secret.yml
+++ b/deploy/config/k8s/k8s-secret.yml
@@ -8,4 +8,5 @@ stringData:
     secret: secrets/test_secret
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
+    var_with_umlaut: secrets/umlaut
   non-conjur-key: some-value

--- a/deploy/config/k8s/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/k8s/test-env-k8s-rotation.sh.yml
@@ -64,6 +64,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_pluses
+          - name: VARIABLE_WITH_UMLAUT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_umlaut
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -51,6 +51,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_pluses
+          - name: VARIABLE_WITH_UMLAUT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_umlaut
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/config/openshift/k8s-secret.yml
+++ b/deploy/config/openshift/k8s-secret.yml
@@ -8,4 +8,5 @@ stringData:
     secret: secrets/test_secret
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
+    var_with_umlaut: secrets/umlaut
   non-conjur-key: some-value

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -50,6 +50,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_pluses
+          - name: VARIABLE_WITH_UMLAUT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_umlaut
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -41,6 +41,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_pluses
+          - name: VARIABLE_WITH_UMLAUT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_umlaut
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
@@ -64,6 +64,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_pluses
+          - name: VARIABLE_WITH_UMLAUT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_umlaut
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/policy/load_policies.sh
+++ b/deploy/policy/load_policies.sh
@@ -35,6 +35,7 @@ done
 conjur variable values add secrets/test_secret "some-secret"
 conjur variable values add "secrets/var with spaces" "some-secret"
 conjur variable values add "secrets/var+with+pluses" "some-secret"
+conjur variable values add "secrets/umlaut" "some-secret"
 conjur variable values add secrets/url "postgresql://test-app-backend.app-test.svc.cluster.local:5432"
 conjur variable values add secrets/username "some-user"
 conjur variable values add secrets/password "7H1SiSmYp@5Sw0rd"

--- a/deploy/policy/templates/conjur-secrets.template.sh.yml
+++ b/deploy/policy/templates/conjur-secrets.template.sh.yml
@@ -11,6 +11,7 @@ cat << EOL
       - !variable another_test_secret
       - !variable var with spaces
       - !variable var+with+pluses
+      - !variable umlaut
       - !variable url
       - !variable username
       - !variable password

--- a/deploy/test/test_cases/TEST_ID_1.5_providing_variables_with_german_umlaut_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_1.5_providing_variables_with_german_umlaut_successfully.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+
+create_secret_access_role
+
+create_secret_access_role_binding
+
+test_secret_is_provided "ÄäÖöÜü" "secrets/umlaut" "VARIABLE_WITH_UMLAUT_SECRET"

--- a/pkg/secrets/clients/conjur/conjur_client.go
+++ b/pkg/secrets/clients/conjur/conjur_client.go
@@ -8,13 +8,13 @@ import (
 )
 
 /*
-	Client for communication with Conjur. In this project it is used only for
-    batch secrets retrieval so we expose only this method of the client.
+Client for communication with Conjur. In this project it is used only for
+batch secrets retrieval so we expose only this method of the client.
 
-	The name ConjurClient also improves readability as Client can be ambiguous.
+The name ConjurClient also improves readability as Client can be ambiguous.
 */
 type ConjurClient interface {
-	RetrieveBatchSecrets([]string) (map[string][]byte, error)
+	RetrieveBatchSecretsSafe([]string) (map[string][]byte, error)
 }
 
 func NewConjurClient(tokenData []byte) (ConjurClient, error) {

--- a/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
+++ b/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
@@ -83,7 +83,7 @@ func retrieveConjurSecrets(accessToken []byte, variableIDs []string) (map[string
 		return nil, log.RecordedError(messages.CSPFK033E)
 	}
 
-	retrievedSecretsByFullIDs, err := conjurClient.RetrieveBatchSecrets(variableIDs)
+	retrievedSecretsByFullIDs, err := conjurClient.RetrieveBatchSecretsSafe(variableIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
@@ -18,6 +18,8 @@ var testConjurSecrets = map[string]string{
 	"conjur/var/path2":        "secret-value2",
 	"conjur/var/path3":        "secret-value3",
 	"conjur/var/path4":        "secret-value4",
+	"conjur/var/umlaut":       "ÄäÖöÜü",
+	"conjur/var/binary":       "\xf0\xff\x4a\xc3",
 	"conjur/var/empty-secret": "",
 }
 
@@ -281,6 +283,42 @@ func TestProvide(t *testing.T) {
 				assertSecretsUpdated(
 					expectedK8sSecrets{
 						"k8s-secret1": {"secret1": ""},
+					},
+					expectedMissingValues{},
+					false,
+				),
+			},
+		},
+		{
+			desc: "Happy path, secret with umlaut characters",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {"secret1": "conjur/var/umlaut"},
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {"secret1": "ÄäÖöÜü"},
+					},
+					expectedMissingValues{},
+					false,
+				),
+			},
+		},
+		{
+			desc: "Happy path, binary secret",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {"secret1": "conjur/var/binary"},
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {"secret1": "\xf0\xff\x4a\xc3"},
 					},
 					expectedMissingValues{},
 					false,


### PR DESCRIPTION
### Desired Outcome

Enable Secrets Provider to deliver secrets with special characters/binary values.

### Implemented Changes

In [conjur#1989](https://github.com/cyberark/conjur/pull/1989), the `/secrets` endpoint was updated to allow for the batch retrieval of secrets with binary values - adding the `Accept-Encoding` header set to `base64` means Conjur will base64 encode secret values before attempting to render response JSON.

We can use that functionality here to enable Secrets Provider to deliver binary/special character secrets by switching `client.RetrieveBatchSecrets()` to `client.RetrieveBatchSecretsSafe()`.

### Connected Issue/Story

CNJR-466

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
