### PR TITLE
Add ImagePullSecret to Helm deployment

### DIFF
--- a/deploy/1_check_dependencies.sh
+++ b/deploy/1_check_dependencies.sh
@@ -18,6 +18,7 @@ check_env_var "APP_NAMESPACE_NAME"
 if [[ "${DEV}" = "false" ]]; then
   check_env_var "DOCKER_REGISTRY_PATH"
   check_env_var "DOCKER_REGISTRY_URL"
+  check_env_var "IMAGE_PULL_SECRET"
 
   if [[ "$PLATFORM" = "openshift" ]]; then
     check_env_var "OPENSHIFT_USERNAME"

--- a/deploy/summon/secrets.yml
+++ b/deploy/summon/secrets.yml
@@ -15,6 +15,8 @@ common:
   OPENSHIFT_USERNAME: ""
   OPENSHIFT_PASSWORD: ""
 
+  IMAGE_PULL_SECRET: dockerpullsecret
+
 gke:
   GCLOUD_CLUSTER_NAME: !var ci/gke/rapid/cluster-name
   GCLOUD_ZONE: !var ci/gke/zone

--- a/deploy/test/test_cases/test_case_setup.sh
+++ b/deploy/test/test_cases/test_case_setup.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 if [ "${DEV}" = "false" ]; then
   announce "Creating image pull secret."
   if [[ "${PLATFORM}" == "kubernetes" ]]; then
-   $cli_with_timeout delete --ignore-not-found secret dockerpullsecret
+   $cli_with_timeout delete --ignore-not-found secret $IMAGE_PULL_SECRET
 
    $cli_with_timeout create secret docker-registry dockerpullsecret \
     --docker-server="${PULL_DOCKER_REGISTRY_URL}" \
@@ -14,7 +14,7 @@ if [ "${DEV}" = "false" ]; then
   elif [[ "$PLATFORM" == "openshift" ]]; then
     $cli_with_timeout delete --ignore-not-found secrets dockerpullsecret
 
-    $cli_with_timeout create secret docker-registry dockerpullsecret \
+    $cli_with_timeout create secret docker-registry $IMAGE_PULL_SECRET \
       --docker-server="${PULL_DOCKER_REGISTRY_PATH}" \
       --docker-username=_ \
       --docker-password=$($cli_with_timeout whoami -t) \

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -123,6 +123,7 @@ runDockerCommand() {
       -e CONJUR_DEPLOYMENT \
       -e RUN_IN_DOCKER \
       -e SUMMON_ENV \
+      -e IMAGE_PULL_SECRET \
       -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v ~/.config:/root/.config \
@@ -165,6 +166,7 @@ runDockerCommand() {
       -e CONJUR_DEPLOYMENT \
       -e RUN_IN_DOCKER \
       -e SUMMON_ENV \
+      -e IMAGE_PULL_SECRET \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v ~/.config:/root/.config \
       -v "$PWD/../helm":/helm \
@@ -286,6 +288,7 @@ fill_helm_chart() {
       -e "s#{{ DEBUG }}# ${DEBUG:-"false"}#g" \
       -e "s#{{ RETRY_COUNT_LIMIT }}# ${RETRY_COUNT_LIMIT:-"5"}#g" \
       -e "s#{{ RETRY_INTERVAL_SEC }}# ${RETRY_INTERVAL_SEC:-"5"}#g" \
+      -e "s#{{ IMAGE_PULL_SECRET }}# ${IMAGE_PULL_SECRET:-""}#g" \
       "$helm_path/helm/secrets-provider/ci/test-values-template.yaml" > "$helm_path/helm/secrets-provider/ci/${id}test-values-$UNIQUE_TEST_ID.yaml"
   done
 }

--- a/helm/secrets-provider/ci/test-values-template.yaml
+++ b/helm/secrets-provider/ci/test-values-template.yaml
@@ -15,6 +15,7 @@ secretsProvider:
   imagePullPolicy: {{ IMAGE_PULL_POLICY }}
   tag: {{ TAG }}
   name: cyberark-secrets-provider-for-k8s
+  imagePullSecret: {{ IMAGE_PULL_SECRET }}
 
 # Additional labels to apply to all resources.
 labels: { {{ LABELS }} }

--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -110,5 +110,9 @@ spec:
                   expirationSeconds: {{ .Values.environment.conjur.authnJWT.expiration }}
                   audience: {{ .Values.environment.conjur.authnJWT.audience }}
       {{- end }}
+      {{- if .Values.secretsProvider.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.secretsProvider.imagePullSecret }}
+      {{- end }}
       restartPolicy: Never
   backoffLimit: 0

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -18,6 +18,8 @@ secretsProvider:
   name: cyberark-secrets-provider-for-k8s
   # Optional: Kubernetes Job name. Defaults to Helm Release.
   jobName:
+  # Optional: Name of image pull secret, if Secrets Provider image is in private repository
+  imagePullSecret:
 
 # OPTIONAL: Additional labels to apply to Job resource.
 labels: {}


### PR DESCRIPTION
### Desired Outcome

Address flaky integration tests. The following error only arises during test cases that use the Helm chart to deploy Secrets Provider:
```
++++++++++++++++++++++++++++++++++++++
Running './TEST_ID_20_helm_multiple_provider_same_serviceaccount.sh'.
++++++++++++++++++++++++++++++++++++++
...
+ oc wait --for=condition=complete --timeout=300s job/secrets-provider
error: timed out waiting for the condition on jobs/secrets-provider
...
Error from server (BadRequest): container "cyberark-secrets-provider-for-k8s" in pod "secrets-provider-8nxwx" is waiting to start: trying and failing to pull image
```

An image pull secret is created [here](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/deploy/test/test_cases/test_case_setup.sh), used in each [Helm-less test case](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/deploy/config/openshift/test-env.sh.yml#L105-L106), but not included in the Helm chart.

### Implemented Changes

Added `ImagePullSecret` field to Helm chart - GKE and OCP integration tests pass for 6 straight runs.

If an `ImagePullSecret` was not included in the Helm chart, why are image pull errors only intermittent?

### Connected Issue/Story

CNJR-83

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
