### PR TITLE
Decode base64 K8s secrets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ junit.xml
 # Temporary directory to store the CyberArk proxy CA certificate
 build_ca_certificate/
 
-# Ignore generated policy files
-deploy/policy/generated/
+# Ignore generated policy files and manifests
+deploy/**/generated/

--- a/deploy/config/k8s/k8s-secret.yml
+++ b/deploy/config/k8s/k8s-secret.yml
@@ -9,4 +9,7 @@ stringData:
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
     var_with_umlaut: secrets/umlaut
+    var_with_encoded:
+      id: secrets/encoded
+      content-type: base64
   non-conjur-key: some-value

--- a/deploy/config/openshift/k8s-secret.yml
+++ b/deploy/config/openshift/k8s-secret.yml
@@ -9,4 +9,7 @@ stringData:
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
     var_with_umlaut: secrets/umlaut
+    var_with_encoded:
+      id: secrets/encoded
+      content-type: base64
   non-conjur-key: some-value

--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -46,6 +46,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_umlaut
+          - name: VARIABLE_WITH_ENCODED_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_encoded
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
@@ -69,6 +69,11 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: var_with_umlaut
+          - name: VARIABLE_WITH_ENCODED_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: var_with_encoded
           - name: NON_CONJUR_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/policy/load_policies.sh
+++ b/deploy/policy/load_policies.sh
@@ -34,6 +34,7 @@ conjur variable set -i secrets/test_secret -v "some-secret"
 conjur variable set -i "secrets/var with spaces" -v "some-secret"
 conjur variable set -i "secrets/var+with+pluses" -v "some-secret"
 conjur variable set -i "secrets/umlaut" -v "some-secret"
+conjur variable set -i "secrets/encoded" -v "c2VjcmV0LXZhbHVl" # == secret-value
 conjur variable set -i secrets/url -v "postgresql://test-app-backend.app-test.svc.cluster.local:5432"
 conjur variable set -i secrets/username -v "some-user"
 conjur variable set -i secrets/password -v "7H1SiSmYp@5Sw0rd"

--- a/deploy/policy/templates/conjur-secrets.template.sh.yml
+++ b/deploy/policy/templates/conjur-secrets.template.sh.yml
@@ -12,6 +12,7 @@ cat << EOL
       - !variable var with spaces
       - !variable var+with+pluses
       - !variable umlaut
+      - !variable encoded
       - !variable url
       - !variable username
       - !variable password

--- a/deploy/utils.sh
+++ b/deploy/utils.sh
@@ -332,6 +332,7 @@ deploy_chart() {
 }
 
 set_config_directory_path() {
+  export DEV_CONFIG_DIR="dev/config/k8s"
   export CONFIG_DIR="config/k8s"
   if [[ "$PLATFORM" = "openshift" ]]; then
     export CONFIG_DIR="config/openshift"
@@ -380,8 +381,9 @@ deploy_init_env() {
   echo "Running Deployment Manifest"
 
   if [[ "$DEV" = "true" ]]; then
-    ./dev/config/k8s/secrets-provider-init-container.sh.yml > ./dev/config/k8s/secrets-provider-init-container.yml
-    $cli_with_timeout apply -f ./dev/config/k8s/secrets-provider-init-container.yml
+    mkdir -p $DEV_CONFIG_DIR/generated
+    $DEV_CONFIG_DIR/secrets-provider-init-container.sh.yml > $DEV_CONFIG_DIR/generated/secrets-provider-init-container.yml
+    $cli_with_timeout apply -f $DEV_CONFIG_DIR/generated/secrets-provider-init-container.yml
 
     $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=init-env --no-headers | wc -l"
   else
@@ -407,8 +409,9 @@ deploy_k8s_rotation_env() {
   echo "Running Deployment Manifest"
 
   if [[ "$DEV" = "true" ]]; then
-    ./dev/config/k8s/secrets-provider-k8s-rotation.sh.yml > ./dev/config/k8s/secrets-provider-k8s-rotation.yml
-    $cli_with_timeout apply -f ./dev/config/k8s/secrets-provider-k8s-rotation.yml
+    mkdir -p $DEV_CONFIG_DIR/generated
+    $DEV_CONFIG_DIR/secrets-provider-k8s-rotation.sh.yml > $DEV_CONFIG_DIR/generated/secrets-provider-k8s-rotation.yml
+    $cli_with_timeout apply -f $DEV_CONFIG_DIR/generated/secrets-provider-k8s-rotation.yml
 
     $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=test-app --no-headers | wc -l"
   else
@@ -649,8 +652,9 @@ deploy_push_to_file() {
   deployment_name="test-env"
 
   if [[ "$DEV" = "true" ]]; then
-    "./dev/config/k8s/$dev_yaml_file_name.sh.yml" > "./dev/config/k8s/$dev_yaml_file_name.yml"
-    $cli_with_timeout apply -f "./dev/config/k8s/$dev_yaml_file_name.yml"
+    mkdir -p $DEV_CONFIG_DIR/generated
+    "$DEV_CONFIG_DIR/$dev_yaml_file_name.sh.yml" > "$DEV_CONFIG_DIR/generated/$dev_yaml_file_name.yml"
+    $cli_with_timeout apply -f "$DEV_CONFIG_DIR/generated/$dev_yaml_file_name.yml"
 
     $cli_with_timeout "get pods --namespace=$APP_NAMESPACE_NAME --selector app=$deployment_name --no-headers | wc -l"
   else

--- a/pkg/log/messages/error_messages.go
+++ b/pkg/log/messages/error_messages.go
@@ -84,3 +84,6 @@ const CSPFK058E string = "CSPFK058E Could not rename temporary file '%s' to '%s'
 const CSPFK059E string = "CSPFK059E Could not delete temporary file '%s'. Truncated file."
 const CSPFK060E string = "CSPFK060E Could not delete temporary file '%s'. File may be left on disk."
 const CSPFK061E string = "CSPFK061E Could not write content to temporary file for '%s'"
+
+// Secrets Decoding
+const CSPFK064E string = "CSPFK064E Failed to decode secret '%s' with '%s' content-type. Reason: %s"


### PR DESCRIPTION
### Desired Outcome

Add decoding of base64 secrets based on content-type annotation in the secrets manifest

### Implemented Changes

- Adds helper func `createSecretData` which decodes secret values based on content-type
- Adds unit/integration tests
- Updates dev environment for K8s secrets mode with decoded secret

Manually tested with init container config:
```sh
kubectl exec $test_pod --namespace local-secrets-provider -- printenv VARIABLE_WITH_ENCODED_SECRET
```
Output:
```sh
secret-value
```

Manually tested with sidecar (rotation) config:
```sh
kubectl exec $test_pod --namespace local-secrets-provider -- printenv VARIABLE_WITH_ENCODED_SECRET && \
echo "Updating Conjur secret value" && \
kubectl exec $cli_pod --namespace local-conjur -- conjur variable set -i secrets/encoded -v "aGVsbG8gd29ybGQ=" && \
echo "Sleeping for 45s while secrets refresh…" && sleep 45 && \
kubectl exec $test_pod --namespace local-secrets-provider -- printenv VARIABLE_WITH_ENCODED_SECRET
```
Output:
```sh
secret-value
Updating Conjur secret value
Value added
Sleeping for 45s while secrets refresh…
hello world
```

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
