### PR TITLE
Simplify dev/test environment deployment

### DIFF
--- a/bootstrap.env
+++ b/bootstrap.env
@@ -24,5 +24,6 @@ export APP_NAMESPACE_NAME=app-$UNIQUE_TEST_ID
 # export CONJUR_LOG_LEVEL=debug
 # export CONJUR_AUTHENTICATORS=authn-k8s/${AUTHENTICATOR_ID}
 # export DEV=true
+# export SECRETS_MODE=k8s # Supported: [k8s, k8s-rotation, p2f, p2f-rotation]
 # Uncomment to deploy the Secrets Provider using HELM
 # export DEV_HELM=true

--- a/deploy/dev/5_load_environment.sh
+++ b/deploy/dev/5_load_environment.sh
@@ -26,7 +26,7 @@ main() {
 
     create_secret_access_role_binding
 
-    deploy_init_env
+    deploy_env
   fi
 }
 

--- a/deploy/dev/config/k8s/secrets-provider-init-push-to-file.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-push-to-file.sh.yml
@@ -59,7 +59,7 @@ spec:
         conjur.org/secret-file-format.group5: template
     spec:
       containers:
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
+      - image: debian
         name: test-app
         command: ["sleep"]
         args: ["infinity"]
@@ -68,8 +68,8 @@ spec:
             name: conjur-secrets
             readOnly: true
       initContainers:
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
-        imagePullPolicy: Always
+      - image: 'secrets-provider-for-k8s:latest'
+        imagePullPolicy: Never
         name: cyberark-secrets-provider-for-k8s
         volumeMounts:
           - mountPath: /conjur/secrets

--- a/deploy/dev/config/k8s/secrets-provider-p2f-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-p2f-rotation.sh.yml
@@ -67,7 +67,7 @@ spec:
         conjur.org/secret-file-format.group5: template
     spec:
       containers:
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/debian:latest'
+      - image: debian
         name: test-app
         command: ["sleep"]
         args: ["infinity"]
@@ -75,8 +75,8 @@ spec:
           - mountPath: /opt/secrets/conjur
             name: conjur-secrets
             readOnly: true
-      - image: '${PULL_DOCKER_REGISTRY_PATH}/${APP_NAMESPACE_NAME}/secrets-provider:latest'
-        imagePullPolicy: Always
+      - image: 'secrets-provider-for-k8s:latest'
+        imagePullPolicy: Never
         name: cyberark-secrets-provider-for-k8s
         volumeMounts:
           - mountPath: /conjur/secrets

--- a/deploy/dev/reload.sh
+++ b/deploy/dev/reload.sh
@@ -44,7 +44,7 @@ main() {
 
     $cli_with_timeout "delete deployment init-env --ignore-not-found=true"
 
-    deploy_init_env
+    deploy_env
   fi
 }
 

--- a/deploy/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
+++ b/deploy/test/test_cases/TEST_ID_12_no_conjur_secrets_permissions.sh
@@ -7,7 +7,7 @@ create_secret_access_role_binding
 
 export CONJUR_AUTHN_LOGIN="host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/service_account/${APP_NAMESPACE_NAME}-sa"
 
-deploy_init_env
+deploy_env
 
 echo "Expecting secrets provider to fail with error CSPFK034E Failed to retrieve Conjur secrets"
 pod_name="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"

--- a/deploy/test/test_cases/TEST_ID_13_host_not_in_apps.sh
+++ b/deploy/test/test_cases/TEST_ID_13_host_not_in_apps.sh
@@ -7,7 +7,7 @@ create_secret_access_role_binding
 
 export CONJUR_AUTHN_LOGIN="host/some-apps/${APP_NAMESPACE_NAME}/*/*"
 
-deploy_init_env
+deploy_env
 
 echo "Verifying pod test_env has environment variable 'TEST_SECRET' with value 'supersecret'"
 pod_name="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"

--- a/deploy/test/test_cases/TEST_ID_14_host_in_root_policy.sh
+++ b/deploy/test/test_cases/TEST_ID_14_host_in_root_policy.sh
@@ -7,7 +7,7 @@ create_secret_access_role_binding
 
 export CONJUR_AUTHN_LOGIN="host/${APP_NAMESPACE_NAME}/*/*"
 
-deploy_init_env
+deploy_env
 
 echo "Verifying pod test_env has environment variable 'TEST_SECRET' with value 'supersecret'"
 pod_name="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"

--- a/deploy/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
+++ b/deploy/test/test_cases/TEST_ID_15_host_with_application_identity_in_annotations.sh
@@ -7,7 +7,7 @@ create_secret_access_role_binding
 
 export CONJUR_AUTHN_LOGIN="host/some-apps/annotations-app"
 
-deploy_init_env
+deploy_env
 
 echo "Verifying pod test_env has environment variable 'TEST_SECRET' with value 'supersecret'"
 pod_name="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"

--- a/deploy/test/test_cases/TEST_ID_16_non_conjur_keys_stay_intact_in_k8s_secret.sh
+++ b/deploy/test/test_cases/TEST_ID_16_non_conjur_keys_stay_intact_in_k8s_secret.sh
@@ -8,7 +8,7 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-deploy_init_env
+deploy_env
 
 k8s_secret_key="NON_CONJUR_SECRET"
 secret_value="some-value"

--- a/deploy/test/test_cases/TEST_ID_27_push_to_file.sh
+++ b/deploy/test/test_cases/TEST_ID_27_push_to_file.sh
@@ -7,7 +7,8 @@ echo "Deploying test_env without CONTAINER_MODE environment variable"
 export CONTAINER_MODE_KEY_VALUE=$KEY_VALUE_NOT_EXIST
 
 echo "Running Deployment push to file"
-deploy_push_to_file "secrets-provider-init-push-to-file" "test-env-push-to-file"
+export SECRETS_MODE="p2f"
+deploy_env
 
 echo "Expecting secrets provider to succeed as an init container"
 

--- a/deploy/test/test_cases/TEST_ID_28_push_to_file_secrets_rotation.sh
+++ b/deploy/test/test_cases/TEST_ID_28_push_to_file_secrets_rotation.sh
@@ -8,8 +8,8 @@ echo "Deploying test_env without CONTAINER_MODE environment variable"
 export CONTAINER_MODE_KEY_VALUE=$KEY_VALUE_NOT_EXIST
 
 echo "Running Deployment push-to-file secrets rotation"
-
-deploy_push_to_file "secrets-provider-p2f-rotation" "test-env-p2f-rotation"
+export SECRETS_MODE="p2f-rotation"
+deploy_env
 
 echo "Expecting secrets provider to succeed as a sidecar container"
 

--- a/deploy/test/test_cases/TEST_ID_29_k8s_secrets_rotation.sh
+++ b/deploy/test/test_cases/TEST_ID_29_k8s_secrets_rotation.sh
@@ -5,7 +5,8 @@ create_secret_access_role
 
 create_secret_access_role_binding
 
-deploy_k8s_rotation_env
+export SECRETS_MODE="k8s-rotation"
+deploy_env
 
 pod_name1="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"
 

--- a/deploy/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
+++ b/deploy/test/test_cases/TEST_ID_2_multiple_pods_changing_pwd_inbetween.sh
@@ -7,7 +7,7 @@ wait_for_it 600  "$CONFIG_DIR/secrets-access-role.sh.yml | $cli_without_timeout 
 echo "Creating secrets access role binding"
 wait_for_it 600 "$CONFIG_DIR/secrets-access-role-binding.sh.yml | $cli_without_timeout apply -f -"
 
-deploy_init_env
+deploy_env
 
 pod_name1="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"
 


### PR DESCRIPTION
### Desired Outcome

Clean up some redundancies in the deployment scripts, and make it simpler to specify which mode to run Secrets Provider in.

### Implemented Changes

- Consolidated deploy_init_env, deploy_k8s_rotation_env, and deploy_push_to_file into one function
- Update test cases and dev bootstrap.env to use `SECRETS_MODE` to set the mode for deployment

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
