### PR TITLE
Null out local variables containing secrets after use

### DIFF
--- a/deploy/test/test_cases/TEST_ID_1.7_providing_large_decoded_variable_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_1.7_providing_large_decoded_variable_successfully.sh
@@ -20,7 +20,7 @@ echo "Verifying pod test_env has environment variable '$environment_variable_nam
 test_pod="$(get_pod_name "$APP_NAMESPACE_NAME" 'app=test-env')"
 actual_value=$($cli_with_timeout "exec $test_pod -- printenv | grep VARIABLE_WITH_BASE64_SECRET | cut -d= -f2")
 
-if [[ "$actual_value" == "$secret_value" ]]; then
+if [[ "$actual_value" == "$secret_value"* ]]; then
     echo "$environment_variable_name is set correctly"
     # Reset the secret value to the original value for subsequent tests
     set_conjur_secret secrets/encoded "$(echo "secret-value" | tr -d '\n' | base64)" # == "c2VjcmV0LXZhbHVl"

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/cyberark/conjur-api-go v0.11.0 h1:LIkdS0zSi2o9AlOwqrIAowxg26kyPFG+XOZ
 github.com/cyberark/conjur-api-go v0.11.0/go.mod h1:AbU7bDVW6ygUdgTDCKkh4wyfIVrOtdEeE/r01OE1EYo=
 github.com/cyberark/conjur-authn-k8s-client v0.24.0 h1:M8Xd6+ztymxQiXUMfVdvpfsTQXJE059CfKVFMDyP1qo=
 github.com/cyberark/conjur-authn-k8s-client v0.24.0/go.mod h1:+Yeek99Ijq2IB3WYHx+Wp9aUfyMm42WjZshVlbtIKcg=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-859 h1:Mm/kEw/EeJvGAxnWVmSfRHSWxCe7MAkOV0nUG//4NJo=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-859/go.mod h1:knGjmz7WYYptFxOwbMTHD56oslEQrNTq2mDW9qix0fc=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-936 h1:ykZLbjIzQHPfF5v3mYfXEUap5SqaV4EIXuG8PveygMk=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-936/go.mod h1:knGjmz7WYYptFxOwbMTHD56oslEQrNTq2mDW9qix0fc=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
@@ -404,22 +404,25 @@ func (p K8sProvider) createSecretData(conjurSecrets map[string][]byte) map[strin
 
 			// Check if the secret value should be decoded in this K8s Secret
 			if dest.contentType == "base64" {
-				decodedSecretValue, err := base64.StdEncoding.DecodeString(string(secretValue))
+				decodedSecretValue := make([]byte, base64.StdEncoding.DecodedLen(len(secretValue)))
+				_, err := base64.StdEncoding.Decode(decodedSecretValue, secretValue)
+				decodedSecretValue = bytes.Trim(decodedSecretValue, "\x00")
 				if err != nil {
 					// Log the error as a warning but still provide the original secret value
 					p.log.warn(messages.CSPFK064E, secretName, dest.contentType, err.Error())
 					secretData[k8sSecretName][secretName] = secretValue
 				} else {
 					secretData[k8sSecretName][secretName] = decodedSecretValue
-					decodedSecretValue = nil
 				}
+				// Null out the secret values
+				decodedSecretValue = []byte{}
 			} else {
 				secretData[k8sSecretName][secretName] = secretValue
 			}
 		}
 		// Null out the secret values
 		conjurSecrets[variableID] = []byte{}
-		secretValue = nil
+		secretValue = []byte{}
 	}
 
 	return secretData

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
@@ -411,13 +411,15 @@ func (p K8sProvider) createSecretData(conjurSecrets map[string][]byte) map[strin
 					secretData[k8sSecretName][secretName] = secretValue
 				} else {
 					secretData[k8sSecretName][secretName] = decodedSecretValue
+					decodedSecretValue = nil
 				}
 			} else {
 				secretData[k8sSecretName][secretName] = secretValue
 			}
 		}
-		// Null out the secret value
+		// Null out the secret values
 		conjurSecrets[variableID] = []byte{}
+		secretValue = nil
 	}
 
 	return secretData

--- a/pkg/secrets/pushtofile/retrieve_secrets.go
+++ b/pkg/secrets/pushtofile/retrieve_secrets.go
@@ -1,6 +1,7 @@
 package pushtofile
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -44,14 +45,16 @@ func FetchSecretsForGroups(
 				return nil, err
 			}
 			if spec.ContentType == "base64" {
-				decodedSecretValue, err := base64.StdEncoding.DecodeString(string(sValue))
+				decodedSecretValue := make([]byte, base64.StdEncoding.DecodedLen(len(sValue)))
+				_, err := base64.StdEncoding.Decode(decodedSecretValue, sValue)
+				decodedSecretValue = bytes.Trim(decodedSecretValue, "\x00")
 				if err != nil {
 					// Log the error as a warning but still provide the original secret value
 					log.Warn(messages.CSPFK064E, spec.Alias, spec.ContentType, err.Error())
 				} else {
 					sValue = decodedSecretValue
-					decodedSecretValue = nil
 				}
+				decodedSecretValue = []byte{}
 			}
 			secretsByGroup[group.Name] = append(
 				secretsByGroup[group.Name],
@@ -60,7 +63,7 @@ func FetchSecretsForGroups(
 					Value: string(sValue),
 				},
 			)
-			sValue = nil
+			sValue = []byte{}
 		}
 	}
 

--- a/pkg/secrets/pushtofile/retrieve_secrets.go
+++ b/pkg/secrets/pushtofile/retrieve_secrets.go
@@ -50,6 +50,7 @@ func FetchSecretsForGroups(
 					log.Warn(messages.CSPFK064E, spec.Alias, spec.ContentType, err.Error())
 				} else {
 					sValue = decodedSecretValue
+					decodedSecretValue = nil
 				}
 			}
 			secretsByGroup[group.Name] = append(
@@ -59,6 +60,7 @@ func FetchSecretsForGroups(
 					Value: string(sValue),
 				},
 			)
+			sValue = nil
 		}
 	}
 

--- a/pkg/secrets/pushtofile/retrieve_secrets_test.go
+++ b/pkg/secrets/pushtofile/retrieve_secrets_test.go
@@ -174,13 +174,13 @@ func newMockSecretFetcher() mockSecretFetcher {
 
 	m.conjurMockClient.AddSecrets(
 		map[string]string{
-			"dev/openshift/api-url":  "https://postgres.example.com",
-			"dev/openshift/username": "admin",
-			"dev/openshift/password": "open-$e$ame",
-			"ci/openshift/api-url":   "https://ci.postgres.example.com",
-			"ci/openshift/username":  "administrator",
-			"ci/openshift/password":  "open-$e$ame",
-			"ci/openshift/encoded-password":  "b3Blbi0kZSRhbWU=",
+			"dev/openshift/api-url":         "https://postgres.example.com",
+			"dev/openshift/username":        "admin",
+			"dev/openshift/password":        "open-$e$ame",
+			"ci/openshift/api-url":          "https://ci.postgres.example.com",
+			"ci/openshift/username":         "administrator",
+			"ci/openshift/password":         "open-$e$ame",
+			"ci/openshift/encoded-password": "b3Blbi0kZSRhbWU=",
 		},
 	)
 


### PR DESCRIPTION
### Desired Outcome

In security review, we discussed making sure that local variables containing secret values are nulled out to make sure they are no longer in memory after being used.

### Implemented Changes

Explicitly null out local variables which could contain secret values. After some research, this is more reliable and secure with byte slices than strings since Golang treats strings as immutable and may be left hanging around in memory, so switch to using slices where possible

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
