### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.5.0] - 2023-02-13
 
 ### Added
+- Convert cmd/secrets-provider to unit testable entrypoint package.
+  [cyberark/secrets-provider-for-k8s#507](https://github.com/cyberark/secrets-provider-for-k8s/pull/507)
 - Adds support for binary secret values and values with special characters.
   [cyberark/secrets-provider-for-k8s#500](https://github.com/cyberark/secrets-provider-for-k8s/pull/500)
-- Adds support for content-type annotation (K8s secrets) and base64 secrets decoding.
+- Adds support for content-type annotation and base64 secrets decoding feature.
   [cyberark/secrets-provider-for-k8s#508](https://github.com/cyberark/secrets-provider-for-k8s/pull/508)
-- Adds support for content-type annotation (P2F) and base64 secrets decoding.
   [cyberark/secrets-provider-for-k8s#511](https://github.com/cyberark/secrets-provider-for-k8s/pull/511)
-- Updating documentation for base64 decoding.
   [cyberark/secrets-provider-for-k8s#513](https://github.com/cyberark/secrets-provider-for-k8s/pull/513)
+  [cyberark/secrets-provider-for-k8s#512](https://github.com/cyberark/secrets-provider-for-k8s/pull/512)
+  [cyberark/secrets-provider-for-k8s#509](https://github.com/cyberark/secrets-provider-for-k8s/pull/509)
+  [cyberark/secrets-provider-for-k8s#504](https://github.com/cyberark/secrets-provider-for-k8s/pull/504)
+  [cyberark/secrets-provider-for-k8s#506](https://github.com/cyberark/secrets-provider-for-k8s/pull/506)
+- Use Conjur CLI v8.0.
+  [cyberark/secrets-provider-for-k8s#505](https://github.com/cyberark/secrets-provider-for-k8s/pull/505)
+- Add ImagePullSecret to Helm deployment.
+  [cyberark/secrets-provider-for-k8s#503](https://github.com/cyberark/secrets-provider-for-k8s/pull/503)
 
 ## [1.4.6] - 2023-01-26
 
@@ -280,7 +288,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.6...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.6...v1.5.0
 [1.4.6]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.3...v1.4.4

--- a/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
+++ b/deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh
@@ -26,4 +26,4 @@ $cli_with_timeout "get RoleBinding secrets-provider-role-binding"
 $cli_with_timeout "get ConfigMap cert-config-map"
 
 # Validate that the Secrets Provider took the default image configurations if not supplied and was deployed successfully
-$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.4.6'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"
+$cli_with_timeout "describe job secrets-provider | grep 'cyberark/secrets-provider-for-k8s:1.5.0'" | awk '{print $2}' && $cli_with_timeout "get job secrets-provider -o jsonpath={.status.succeeded}"

--- a/helm/secrets-provider/Chart.yaml
+++ b/helm/secrets-provider/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for deploying CyberArk Secrets Provider for Kubernetes
 name: secrets-provider
-version: 1.4.6
+version: 1.5.0
 home: https://github.com/cyberark/secrets-provider-for-k8s
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/secrets-provider/tests/secrets_provider_test.yaml
+++ b/helm/secrets-provider/tests/secrets_provider_test.yaml
@@ -71,7 +71,7 @@ tests:
       # Confirm that default chart values have been used
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/cyberark/secrets-provider-for-k8s:1.4.6
+          value: docker.io/cyberark/secrets-provider-for-k8s:1.5.0
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/helm/secrets-provider/tests/test-unit
+++ b/helm/secrets-provider/tests/test-unit
@@ -17,4 +17,4 @@ if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then
 fi
 
 # Run a Helm unit test
-helm unittest . --helm3
+helm unittest .

--- a/helm/secrets-provider/values.yaml
+++ b/helm/secrets-provider/values.yaml
@@ -12,7 +12,7 @@ rbac:
 
 secretsProvider:
   image: docker.io/cyberark/secrets-provider-for-k8s
-  tag: 1.4.6
+  tag: 1.5.0
   imagePullPolicy: IfNotPresent
   # Container name
   name: cyberark-secrets-provider-for-k8s

--- a/pkg/secrets/version.go
+++ b/pkg/secrets/version.go
@@ -3,7 +3,7 @@ package secrets
 import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
-var Version = "1.4.6"
+var Version = "1.5.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Need a new release.
Helm unit tests should run.

### Implemented Changes

Update the changelog and bump version to 1.5.0
Also removed the --helm3 flag from the Helm unit tests as Helm 2 is no longer supported
and this flag also no longer supported.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-1086

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
