### PR TITLE
Replace deprecated io/ioutil package

### DIFF
--- a/pkg/atomicwriter/atomic_writer.go
+++ b/pkg/atomicwriter/atomic_writer.go
@@ -2,7 +2,6 @@ package atomicwriter
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,7 +28,7 @@ var stdOSFuncs = osFuncs{
 	sync: func(file *os.File) error {
 		return file.Sync()
 	},
-	tempFile: ioutil.TempFile,
+	tempFile: os.CreateTemp,
 	truncate: os.Truncate,
 	write: func(file *os.File, content []byte) (int, error) {
 		return file.Write(content)

--- a/pkg/atomicwriter/atomic_writer_test.go
+++ b/pkg/atomicwriter/atomic_writer_test.go
@@ -3,7 +3,6 @@ package atomicwriter
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -41,9 +40,8 @@ type injectErrors struct {
 // wraps the equivalent standard OS function, and adds the following
 // functionality for testing:
 //
-//    - Track the number of times that the function was called
-//    - Optionally return an error for testing purposes
-//
+//   - Track the number of times that the function was called
+//   - Optionally return an error for testing purposes
 func newTestOSFuncs(injectErrs injectErrors) (osFuncs, *osFuncCounts) {
 	counts := &osFuncCounts{}
 	funcs := osFuncs{
@@ -124,7 +122,7 @@ func TestWriteAndClose(t *testing.T) {
 				// Check that the file exists
 				assert.FileExists(t, path)
 				// Check the contents of the file
-				contents, err := ioutil.ReadFile(path)
+				contents, err := os.ReadFile(path)
 				assert.NoError(t, err)
 				assert.Equal(t, "test content", string(contents))
 				// Check the file permissions
@@ -170,7 +168,7 @@ func TestWriteAndClose(t *testing.T) {
 			var tempFilePath string
 
 			// Create a temp file for writing secret files
-			tmpDir, _ := ioutil.TempDir("", "atomicwriter")
+			tmpDir, _ := os.MkdirTemp("", "atomicwriter")
 			defer os.RemoveAll(tmpDir)
 
 			// Create a test atomic writer
@@ -194,7 +192,7 @@ func TestWriteAndClose(t *testing.T) {
 }
 
 func TestWriterAtomicity(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "atomicwriter")
+	tmpDir, _ := os.MkdirTemp("", "atomicwriter")
 	defer os.RemoveAll(tmpDir)
 	path := filepath.Join(tmpDir, "test_file.txt")
 	initialContent := "initial content"
@@ -213,7 +211,7 @@ func TestWriterAtomicity(t *testing.T) {
 	writer2.Write([]byte("writer 2 line 2\n"))
 
 	// Ensure the destination file hasn't changed
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	assert.NoError(t, err)
 	assert.Equal(t, initialContent, string(contents))
 
@@ -224,7 +222,7 @@ func TestWriterAtomicity(t *testing.T) {
 	// Check that the file exists
 	assert.FileExists(t, path)
 	// Check the contents of the file match the first writer (which was closed)
-	contents, err = ioutil.ReadFile(path)
+	contents, err = os.ReadFile(path)
 	assert.NoError(t, err)
 	assert.Equal(t, "writer 1 line 1\nwriter 1 line 2\n", string(contents))
 	// Check the file permissions match the first writer
@@ -280,7 +278,7 @@ func TestLogsErrors(t *testing.T) {
 
 				// Check that the temp file was truncated
 				assert.FileExists(t, tempFileName)
-				content, err := ioutil.ReadFile(tempFileName)
+				content, err := os.ReadFile(tempFileName)
 				assert.NoError(t, err)
 				assert.Equal(t, "", string(content))
 			},
@@ -352,7 +350,7 @@ func TestLogsErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, _ := ioutil.TempDir("", "atomicwriter")
+			tmpDir, _ := os.MkdirTemp("", "atomicwriter")
 			defer os.RemoveAll(tmpDir)
 			path := filepath.Join(tmpDir, tc.path)
 

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -171,7 +170,7 @@ func secretRetriever(
 	_, span := tracer.Start(ctx, "Gather authenticator config")
 	defer span.End()
 
-	authnConfig, err := authnConfigProvider.NewConfigFromCustomEnv(ioutil.ReadFile, customEnv)
+	authnConfig, err := authnConfigProvider.NewConfigFromCustomEnv(os.ReadFile, customEnv)
 	if err != nil {
 		span.RecordErrorAndSetStatus(err)
 		log.Error(messages.CSPFK008E)

--- a/pkg/entrypoint/entrypoint_test.go
+++ b/pkg/entrypoint/entrypoint_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +82,7 @@ func (m editableMap) Copy() editableMap {
 }
 
 func TestStartSecretsProvider(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "entrypoint_test")
+	tmpDir, _ := os.MkdirTemp("", "entrypoint_test")
 	defer os.RemoveAll(tmpDir)
 
 	env := map[string]string{

--- a/pkg/secrets/annotations/annotation_parser_test.go
+++ b/pkg/secrets/annotations/annotation_parser_test.go
@@ -3,7 +3,6 @@ package annotations
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -15,7 +14,7 @@ import (
 // that does a no-op for file closing, and returns specified content
 // for read operations.
 func mockReadCloser(contents string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(contents))
+	return io.NopCloser(strings.NewReader(contents))
 }
 
 func mockFileOpenerGenerator(store map[string]io.ReadCloser) fileOpener {

--- a/pkg/secrets/provider_status_test.go
+++ b/pkg/secrets/provider_status_test.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,7 +79,7 @@ type testStatusUpdater struct {
 }
 
 func newTestStatusUpdater(injectErrs injectErrs) (*testStatusUpdater, error) {
-	tempDir, err := ioutil.TempDir("", "secrets-testing")
+	tempDir, err := os.MkdirTemp("", "secrets-testing")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/pushtofile/pull_from_reader.go
+++ b/pkg/secrets/pushtofile/pull_from_reader.go
@@ -2,7 +2,6 @@ package pushtofile
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -19,13 +18,13 @@ func openFileAsReadCloser(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 func pullFromReader(
 	reader io.Reader,
 ) (string, error) {
-	content, err := ioutil.ReadAll(reader)
+	content, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/secrets/pushtofile/secret-group_utils_test.go
+++ b/pkg/secrets/pushtofile/secret-group_utils_test.go
@@ -3,7 +3,6 @@ package pushtofile
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -14,7 +13,7 @@ type ClosableBuffer struct {
 
 func (c ClosableBuffer) Close() error { return c.CloseErr }
 
-//// pushToWriterFunc
+// pushToWriterFunc
 type pushToWriterArgs struct {
 	writer        io.Writer
 	groupName     string
@@ -51,7 +50,7 @@ func (spy *pushToWriterSpy) Call(
 	return spy.targetsUpdated, spy.err
 }
 
-//// openWriteCloserFunc
+// openWriteCloserFunc
 type openWriteCloserArgs struct {
 	path        string
 	permissions os.FileMode
@@ -79,7 +78,7 @@ func (spy *openWriteCloserSpy) Call(path string, permissions os.FileMode) (io.Wr
 	return spy.writeCloser, spy.err
 }
 
-//// pullFromReaderFunc
+// pullFromReaderFunc
 type pullFromReaderArgs struct {
 	reader io.Reader
 }
@@ -103,7 +102,7 @@ func (spy *pullFromReaderSpy) Call(
 		reader: reader,
 	}
 
-	content, err := ioutil.ReadAll(reader)
+	content, err := io.ReadAll(reader)
 	if err != nil {
 		return string(content), err
 	}
@@ -111,7 +110,7 @@ func (spy *pullFromReaderSpy) Call(
 	return string(content), spy.err
 }
 
-//// openReadCloserFunc
+// openReadCloserFunc
 type openReadCloserArgs struct {
 	path string
 }

--- a/pkg/secrets/pushtofile/secret_group.go
+++ b/pkg/secrets/pushtofile/secret_group.go
@@ -2,7 +2,7 @@ package pushtofile
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -204,7 +204,7 @@ func (sg *SecretGroup) validate() []error {
 			dummySecrets = append(dummySecrets, &Secret{Alias: secretSpec.Alias, Value: "REDACTED"})
 		}
 
-		_, err := pushToWriter(ioutil.Discard, groupName, fileTemplate, dummySecrets)
+		_, err := pushToWriter(io.Discard, groupName, fileTemplate, dummySecrets)
 		if err != nil {
 			return []error{fmt.Errorf(
 				`unable to use file template for secret group %q: %s`,

--- a/pkg/secrets/pushtofile/secret_group_test.go
+++ b/pkg/secrets/pushtofile/secret_group_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -530,7 +529,7 @@ func TestNewSecretGroups(t *testing.T) {
 
 	t.Run("custom template - test template file base path", func(t *testing.T) {
 		// Create temp directory
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		assert.NoError(t, err)
 		defer os.Remove(dir)
 		// Write sample template file
@@ -887,7 +886,7 @@ func TestSecretGroup_pushToFileWithDeps(t *testing.T) {
 
 func TestSecretGroup_PushToFile(t *testing.T) {
 	// Create temp directory
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(dir)
 
@@ -937,7 +936,7 @@ func TestSecretGroup_PushToFile(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Read file contents and metadata
-			contentBytes, err := ioutil.ReadFile(absoluteFilePath)
+			contentBytes, err := os.ReadFile(absoluteFilePath)
 			assert.NoError(t, err)
 			f, err := os.Stat(absoluteFilePath)
 			assert.NoError(t, err)


### PR DESCRIPTION
### Desired Outcome

As of Go 1.16 `io/ioutil` is deprecated in favor of functions in `io` or `os` packages.

### Implemented Changes

Replaces `io/ioutil` functions with their replacements in `io` and `os`.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
