### PR TITLE
Publish latest tag on promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.2] - 2023-06-07
+
 ## [1.5.1] - 2023-05-26
 
 ### Security

--- a/bin/publish
+++ b/bin/publish
@@ -115,16 +115,16 @@ if [[ ${PROMOTE} = true ]]; then
     "latest"
   )
 
+  # Publish images to docker hub
   for tag in "${TAGS[@]}" $(gen_versions "$REMOTE_TAG"); do
     echo "Tagging and pushing $REGISTRY/$IMAGE_NAME:$tag"
     tag_and_push "${LOCAL_REGISTRY}/$IMAGE_NAME:$SOURCE_TAG" "$REGISTRY/$IMAGE_NAME:$tag"
+    tag_and_push "${LOCAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "$REGISTRY/${REDHAT_LOCAL_IMAGE}:$tag"
   done
 
-  # Publish RedHat image to docker hub
-  tag_and_push "${LOCAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "$REGISTRY/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}"
 
   # Publish only latest to Redhat Registries
-  echo "Tagging and pushing ${REDHAT_REMOTE_IMAGE}"
+  echo "Tagging and pushing ${REDHAT_REMOTE_IMAGE} with tag ${REMOTE_TAG}"
   docker tag "${LOCAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"
 
   # Publish RedHat image to RedHat Registry
@@ -137,6 +137,11 @@ if [[ ${PROMOTE} = true ]]; then
 
     # scan image with preflight tool
     scan_redhat_image "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}" "${REDHAT_CERT_PID}"
+
+    # Publish latest tag to Redhat Registry
+    echo "Tagging and pushing ${REDHAT_REMOTE_IMAGE} with tag latest"
+    docker tag "${LOCAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_REMOTE_IMAGE}:latest"
+    docker push "${REDHAT_REMOTE_IMAGE}:latest"
   else
     echo 'Failed to log in to quay.io'
     exit 1


### PR DESCRIPTION
### Desired Outcome

Fix tagging of Redhat images.

### Implemented Changes

Currently we are only publishing the version tagged image, so `latest` is never updated when new images are pushed to the registry

Validated with a dummy release:
![Screenshot 2023-06-07 at 9 42 38 AM](https://github.com/cyberark/secrets-provider-for-k8s/assets/98338376/7820a1f3-11e3-4fd1-93bb-70e30d2b9928)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
