### PR TITLE
CNJR-2306: Make log level configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2023-07-19
+
+### Added
+- Log level is now configurable using the `LOG_LEVEL` environment variable or `conjur.org/log-level` annotation.
+  The existing `DEBUG` environment variable and `conjur.org/debug-logging` annotation is deprecated and will be removed in a future update.
+  [cyberark/secrets-provider-for-k8s#534](https://github.com/cyberark/secrets-provider-for-k8s/pull/534)
+
 ### Security
 - Upgrade google/cloud-sdk to v437.0.0-slim
   [cyberark/secrets-provider-for-k8s#533](https://github.com/cyberark/secrets-provider-for-k8s/pull/533)
 - Upgrade google/cloud-sdk to v435.0.1 and google.golang.org/protobuf to v1.29.1
   [cyberark/secrets-provider-for-k8s#531](https://github.com/cyberark/secrets-provider-for-k8s/pull/531)
-
-## [1.5.2] - 2023-06-07
 
 ## [1.5.1] - 2023-05-26
 
@@ -304,7 +309,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
   - Escape secrets with backslashes before patching in k8s
 
-[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.6...v1.5.0
 [1.4.6]: https://github.com/cyberark/secrets-provider-for-k8s/compare/v1.4.5...v1.4.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in the CyberArk Secrets Provider for Kubernetes. We wel
     + [Go](#go)
   * [Documentation](#documentation)
     + [Get up and running](#get-up-and-running)
-    + [Deploy a Local Dev Environment (K8s)](#deploy-a-local-dev-environment--k8s-)
+    + [Deploy a Local Dev Environment (K8s)](#deploy-a-local-dev-environment-k8s)
       - [Prerequisites](#prerequisites-1)
       - [Deploy a local development environment](#deploy-a-local-development-environment)
       - [Clean-up](#clean-up)
@@ -21,10 +21,9 @@ Thanks for your interest in the CyberArk Secrets Provider for Kubernetes. We wel
       - [Integration testing](#integration-testing)
   * [Releases](#releases)
     + [Pre-requisites](#pre-requisites)
-    + [Update the version, changelog, and notices](#update-the-version--changelog--and-notices)
-    + [Add a git tag](#add-a-git-tag)
+    + [Update the version, changelog, and notices](#update-the-version-changelog-and-notices)
     + [Push Helm package](#push-helm-package)
-    + [Publish the git release](#publish-the-git-release)
+    + [Release and Promote](#release-and-promote)
     + [Publish the Red Hat image](#publish-the-red-hat-image)
 
 ## Prerequisites
@@ -230,7 +229,7 @@ push to file E2E test:
 Releases should be created by maintainers only. To create a tag and release,
 follow the instructions in this section.
 
-### Pre-requisites 
+### Pre-requisites
 
 1. Review the git log and ensure the [changelog](CHANGELOG.md) contains all
    relevant recent changes with references to GitHub issues or PRs, if possible.
@@ -242,6 +241,7 @@ follow the instructions in this section.
 1. Scan the project for vulnerabilities
 
 ### Update the version, changelog, and notices
+
 1. Create a new branch for the version bump.
 1. Based on the changelog content, determine the new version number.
 1. Update this version in the following files:
@@ -252,20 +252,23 @@ follow the instructions in this section.
     1. [Test case hardcoded version](deploy/test/test_cases/TEST_ID_22_helm_rbac_defaults_taken_successfully.sh)
 1. Commit these changes - `Bump version to x.y.z` is an acceptable commit
    message - and open a PR for review.
-   
+
 ### Push Helm package
+
 1. Every build packages the Secrets Provider Helm chart for us. The package can be found under the 'Artifacts' tab of the Jenkins build and will resemble `secrets-provider-<version>.tgz`. 
 Navigate to the 'Artifacts' tab of the _tagged version_ build and save this file. You will need it for the next step.
 1. Clone the repo [helm-charts](https://github.com/cyberark/helm-charts) and do the following:
     1. Move the Helm package file created in the previous step to the *docs* folder in the `helm-charts` repo.
     1. Go to the `helm-charts` repo root folder and execute the `reindex.sh` script file located there.
     1. Create a PR with those changes.
-    
-                                                            
+
 ### Release and Promote
+
 1. Merging into main/master branches will automatically trigger a release. If successful, this release can be promoted at a later time.
 1. Jenkins build parameters can be utilized to promote a successful release or manually trigger aditional releases as needed.
 1. Reference the [internal automated release doc](https://github.com/conjurinc/docs/blob/master/reference/infrastructure/automated_releases.md#release-and-promotion-process) for releasing and promoting.
+
 ### Publish the Red Hat image
-1. Visit the [Red Hat project page](https://connect.redhat.com/project/4381831/view) once the images have been pushed 
+
+1. Visit the [Red Hat project page](https://connect.redhat.com/project/4381831/view) once the images have been pushed
 and manually choose to publish the latest release.

--- a/PUSH_TO_FILE.md
+++ b/PUSH_TO_FILE.md
@@ -323,7 +323,7 @@ for a description of each environment variable setting:
 | `conjur.org/k8s-secrets`            | `K8S_SECRETS`         | This list is ignored when `conjur.org/secrets-destination` annotation is set to **`file`** |
 | `conjur.org/retry-count-limit`      | `RETRY_COUNT_LIMIT`   | Defaults to 5
 | `conjur.org/retry-interval-sec`     | `RETRY_INTERVAL_SEC`  | Defaults to 1 (sec)              |
-| `conjur.org/debug-logging`          | `DEBUG`               | Defaults to `false`              |
+| `conjur.org/log-level`              | `LOG_LEVEL`           | Allowed values: <ul><li>`debug`</li><li>`info`</li><li>`warn`</li><li>`error`</li></ul>Defaults to `info`.               |
 | `conjur.org/conjur-secrets.{secret-group}`      | Note\* | List of secrets to be retrieved from Conjur. Each entry can be either:<ul><li>A Conjur variable path</li><li> A key/value pairs of the form <br>`<alias>:<Conjur variable path>`<br>`[content-type: <type>]`<br>where the `alias` represents the name of the secret to be written to the secrets file and the optional `content-type` is either text or base64, defaulting to text. See [Decoding Base64 Encoded Secrets](#decoding-base64-encoded-secrets) for more information.|
 | `conjur.org/conjur-secrets-policy-path.{secret-group}` | Note\* | Defines a common Conjur policy path, assumed to be relative to the root policy.<br><br>When this annotation is set, the policy paths defined by `conjur.org/conjur-secrets.{secret-group}` are relative to this common path.<br><br>When this annotation is not set, the policy paths defined by `conjur.org/conjur-secrets.{secret-group}` are themselves relative to the root policy.<br><br>(See [Example Common Policy Path](#example-common-policy-path) for an explicit example of this relationship.)|
 | `conjur.org/secret-file-path.{secret-group}`    | Note\* | Relative path for secret file or directory to be written. This path is assumed to be relative to the respective mount path for the shared secrets volume for each container.<br><br>If the `conjur.org/secret-file-format.{secret-group}` is set to `template`, then this secret file path defaults to `{secret-group}.out`. For example, if the secret group name is `my-app`, the the secret file path defaults to `my-app.out`.<br><br>Otherwise, this secret file path defaults to `{secret-group}.{secret-group-file-format}`. For example, if the secret group name is `my-app`, and the secret file format is set for YAML, the the secret file path defaults to `my-app.yaml`.
@@ -1084,12 +1084,12 @@ following changes to the deployment:
 
 This section describes how to troubleshoot common Secrets Provider for Kubernetes issues.
 
-### Enable logs
+### Enable debug logs
 
-To enable logs, add the debug parameter to the application deployment manifest.
+To enable debug logs, add the debug parameter to the application deployment manifest.
 ```
 annotations:
-    conjur.org/debug-logging  "true"
+    conjur.org/log-level  "debug"
 ```
 For details, see [Reference Table of Configuration Annotations](#reference-table-of-configuration-annotations)
 

--- a/deploy/config/k8s/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/k8s/test-env-k8s-rotation.sh.yml
@@ -28,7 +28,7 @@ spec:
         conjur.org/secrets-destination: k8s_secrets
         conjur.org/k8s-secrets: |
           - test-k8s-secret
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
     spec:
       serviceAccountName: ${APP_NAMESPACE_NAME}-sa
       containers:

--- a/deploy/config/k8s/test-env-p2f-rotation.sh.yml
+++ b/deploy/config/k8s/test-env-p2f-rotation.sh.yml
@@ -26,7 +26,7 @@ spec:
         conjur.org/secrets-refresh-enabled: "true"
         conjur.org/secrets-refresh-interval: "10s"
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/deploy/config/k8s/test-env-push-to-file.sh.yml
+++ b/deploy/config/k8s/test-env-push-to-file.sh.yml
@@ -24,7 +24,7 @@ spec:
         conjur.org/authn-identity: '$CONJUR_AUTHN_LOGIN'
         conjur.org/container-mode: init
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -98,8 +98,8 @@ spec:
                 name: conjur-master-ca-env
                 key: ssl-certificate
 
-          - name: DEBUG
-            value: "true"
+          - name: LOG_LEVEL
+            value: "debug"
 
           - name: CONJUR_AUTHN_LOGIN
             value: ${CONJUR_AUTHN_LOGIN}

--- a/deploy/config/openshift/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-k8s-rotation.sh.yml
@@ -27,7 +27,7 @@ spec:
         conjur.org/secrets-destination: k8s_secrets
         conjur.org/k8s-secrets: |
           - test-k8s-secret
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
     spec:
       serviceAccountName: ${APP_NAMESPACE_NAME}-sa
       containers:

--- a/deploy/config/openshift/test-env-p2f-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-p2f-rotation.sh.yml
@@ -25,7 +25,7 @@ spec:
         conjur.org/secrets-refresh-enabled: "true"
         conjur.org/secrets-refresh-interval: "10s"
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/deploy/config/openshift/test-env-push-to-file.sh.yml
+++ b/deploy/config/openshift/test-env-push-to-file.sh.yml
@@ -23,7 +23,7 @@ spec:
         conjur.org/authn-identity: '$CONJUR_AUTHN_LOGIN'
         conjur.org/container-mode: init
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -97,8 +97,8 @@ spec:
                 name: conjur-master-ca-env
                 key: ssl-certificate
 
-          - name: DEBUG
-            value: "true"
+          - name: LOG_LEVEL
+            value: "debug"
 
           - name: CONJUR_AUTHN_LOGIN
             value: ${CONJUR_AUTHN_LOGIN}

--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -97,8 +97,8 @@ spec:
           - name: SECRETS_DESTINATION
             value: k8s_secrets
 
-          - name: DEBUG
-            value: "true"
+          - name: LOG_LEVEL
+            value: "debug"
 
           - name: CONJUR_AUTHN_LOGIN
             value: "host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/*/*"

--- a/deploy/dev/config/k8s/secrets-provider-init-push-to-file.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-push-to-file.sh.yml
@@ -24,7 +24,7 @@ spec:
         conjur.org/authn-identity: '$CONJUR_AUTHN_LOGIN'
         conjur.org/container-mode: init
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
@@ -28,7 +28,7 @@ spec:
         conjur.org/secrets-destination: k8s_secrets
         conjur.org/k8s-secrets: |
           - test-k8s-secret
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
     spec:
       serviceAccountName: ${APP_NAMESPACE_NAME}-sa
       containers:

--- a/deploy/dev/config/k8s/secrets-provider-p2f-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-p2f-rotation.sh.yml
@@ -26,7 +26,7 @@ spec:
         conjur.org/secrets-refresh-enabled: "true"
         conjur.org/secrets-refresh-interval: "10s"
         conjur.org/secrets-destination: file
-        conjur.org/debug-logging: "true"
+        conjur.org/log-level: "debug"
         conjur.org/retry-count-limit: "6"
         conjur.org/retry-interval-sec: "2"
         conjur.org/conjur-secrets.group1: |

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/cyberark/conjur-api-go v0.10.1 // version will be ignored by auto release process
-	github.com/cyberark/conjur-authn-k8s-client v0.23.8 // version will be ignored by auto release process
+	github.com/cyberark/conjur-authn-k8s-client v0.26.0 // version will be ignored by auto release process
 	github.com/cyberark/conjur-opentelemetry-tracer v1.55.55 // version will be ignored by auto release process
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,10 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberark/conjur-api-go v0.11.1 h1:vjaMkw0geJsA+ikMM6UDLg4VLFQWKo/B0i9IWlOQ1f0=
 github.com/cyberark/conjur-api-go v0.11.1/go.mod h1:n1p46Hj9l8wkZjM17cVYdfcatyPboWyioLGlC0QszCs=
-github.com/cyberark/conjur-authn-k8s-client v0.25.1 h1:CrAui950L1jKzMNp+5YvCgDaemJkz8bFqD4wYFqSLv8=
-github.com/cyberark/conjur-authn-k8s-client v0.25.1/go.mod h1:biD4y/VHqPWBzUk/nLoflQ/87f/RAJF4QJnuboKJHOY=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1099 h1:Mjmvr9SDI0g9TKHmd3wzxVDqR9q3lkeknv0qz9kp6F0=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1099/go.mod h1:7pNmWZ/E4jv5cJuFWuXbzHpX6T44JfAPfciTWVxR9Ec=
+github.com/cyberark/conjur-authn-k8s-client v0.25.3-0.20230718150056-8ef20bd68e9d h1:tNlfWTjm6+h6d2BJuB+wfTo8c9wXkGACDSkA/Saag1w=
+github.com/cyberark/conjur-authn-k8s-client v0.25.3-0.20230718150056-8ef20bd68e9d/go.mod h1:biD4y/VHqPWBzUk/nLoflQ/87f/RAJF4QJnuboKJHOY=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1135 h1:M93qiR355OmNWBIMaz4emoCzdPr5qpyscltxHOJpyHU=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1135/go.mod h1:7pNmWZ/E4jv5cJuFWuXbzHpX6T44JfAPfciTWVxR9Ec=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/helm/secrets-provider/templates/secrets-provider.yaml
+++ b/helm/secrets-provider/templates/secrets-provider.yaml
@@ -95,9 +95,9 @@ spec:
           value: {{ .Values.environment.conjur.retryCountLimit | quote }}
         {{- end }}
 
-        {{- if .Values.environment.debug }}
-        - name: DEBUG
-          value: "true"
+        {{- if .Values.environment.logLevel }}
+        - name: LOG_LEVEL
+          value: {{ .Values.environment.logLevel | quote }}
         {{- end }}
 
         {{- if .Values.environment.conjur.conjurConnConfigMap }}

--- a/helm/secrets-provider/values.schema.json
+++ b/helm/secrets-provider/values.schema.json
@@ -173,8 +173,9 @@
             }
           }
         },
-        "debug": {
-          "type": "boolean"
+        "logLevel": {
+          "type": "string",
+          "enum": ["debug", "info", "warn", "error"]
         }
       }
     }

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -42,6 +42,7 @@ var envAnnotationsConversion = map[string]string{
 	"RETRY_COUNT_LIMIT":      "conjur.org/retry-count-limit",
 	"RETRY_INTERVAL_SEC":     "conjur.org/retry-interval-sec",
 	"DEBUG":                  "conjur.org/debug-logging",
+	"LOG_LEVEL":              "conjur.org/log-level",
 	"JAEGER_COLLECTOR_URL":   "conjur.org/jaeger-collector-url",
 	"LOG_TRACES":             "conjur.org/log-traces",
 	"JWT_TOKEN_PATH":         "conjur.org/jwt-token-path",

--- a/pkg/log/messages/debug_messages.go
+++ b/pkg/log/messages/debug_messages.go
@@ -1,6 +1,5 @@
 package messages
 
-const CSPFK001D string = "CSPFK001D Debug mode is enabled"
 const CSPFK002D string = "CSPFK002D Failed to load in-cluster Kubernetes client config. Reason: %s"
 const CSPFK003D string = "CSPFK003D Failed to create Kubernetes client. Reason: %s"
 const CSPFK004D string = "CSPFK004D Failed to retrieve Kubernetes Secret. Reason: %s"

--- a/pkg/log/messages/info_messages.go
+++ b/pkg/log/messages/info_messages.go
@@ -12,19 +12,16 @@ package messages
 			then the compiler will not allow it.
 */
 
-const CSPFK001I string = "CSPFK001I Authenticating as user '%s'"
 const CSPFK002I string = "CSPFK002I Creating DAP/Conjur client"
 const CSPFK003I string = "CSPFK003I Retrieving following secrets from DAP/Conjur: %v"
 const CSPFK004I string = "CSPFK004I Creating Kubernetes client"
 const CSPFK005I string = "CSPFK005I Retrieving Kubernetes secret '%s' from namespace '%s'"
 const CSPFK006I string = "CSPFK006I Updating Kubernetes secret '%s' in namespace '%s'"
-const CSPFK007I string = "CSPFK007I Attempting to re-authenticate: %d retries out of %d"
 const CSPFK008I string = "CSPFK008I CyberArk Secrets Provider for Kubernetes v%s starting up"
 const CSPFK009I string = "CSPFK009I DAP/Conjur Secrets updated in Kubernetes successfully"
 const CSPFK010I string = "CSPFK010I Updating Kubernetes Secrets: %d retries out of %d"
 const CSPFK011I string = "CSPFK011I Annotation '%s' valid, but not recognized"
 const CSPFK012I string = "CSPFK012I Secrets Provider setting '%s' set by both environment variable '%s' and annotation '%s'"
-const CSPFK013I string = "CSPFK013I Gathering settings for Authenticator client configuration..."
 const CSPFK014I string = "CSPFK014I Authenticator setting %s provided by %s"
 const CSPFK015I string = "CSPFK015I DAP/Conjur Secrets pushed to shared volume successfully"
 const CSPFK016I string = "CSPFK016I There are no secrets to be retrieved from Conjur"

--- a/pkg/secrets/annotations/annotation_parser_test.go
+++ b/pkg/secrets/annotations/annotation_parser_test.go
@@ -110,7 +110,7 @@ conjur.org/secrets-destination="k8s_secrets"
 conjur.org/k8s-secrets="- k8s-secret-1\n- k8s-secret-2\n"
 conjur.org/retry-count-limit="10"
 conjur.org/retry-interval-sec="5"
-conjur.org/debug-logging="true"
+conjur.org/log-level="debug"
 conjur.org/conjur-secrets.this-group="- test/url\n- test-password: test/password\n- test-username: test/username\n"
 conjur.org/secret-file-path.this-group="this-relative-path"
 conjur.org/secret-file-format.this-group="yaml"`,
@@ -122,7 +122,7 @@ conjur.org/secret-file-format.this-group="yaml"`,
 				"conjur.org/k8s-secrets":                   "- k8s-secret-1\n- k8s-secret-2\n",
 				"conjur.org/retry-count-limit":             "10",
 				"conjur.org/retry-interval-sec":            "5",
-				"conjur.org/debug-logging":                 "true",
+				"conjur.org/log-level":                     "debug",
 				"conjur.org/conjur-secrets.this-group":     "- test/url\n- test-password: test/password\n- test-username: test/username\n",
 				"conjur.org/secret-file-path.this-group":   "this-relative-path",
 				"conjur.org/secret-file-format.this-group": "yaml",

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -71,6 +71,7 @@ const (
 	// RemoveDeletedSecretsKey is the annotaion key for enabling removing deleted secrets
 	RemoveDeletedSecretsKey = "conjur.org/remove-deleted-secrets-enabled"
 	debugLoggingKey         = "conjur.org/debug-logging"
+	logLevelKey             = "conjur.org/log-level"
 	logTracesKey            = "conjur.org/log-traces"
 	jaegerCollectorUrl      = "conjur.org/jaeger-collector-url"
 )
@@ -88,6 +89,7 @@ var secretsProviderAnnotations = map[string]annotationRestraints{
 	SecretsRefreshEnabledKey:  {TYPEBOOL, []string{}},
 	RemoveDeletedSecretsKey:   {TYPEBOOL, []string{}},
 	debugLoggingKey:           {TYPEBOOL, []string{}},
+	logLevelKey:               {TYPESTRING, []string{"debug", "info", "warn", "error"}},
 	logTracesKey:              {TYPEBOOL, []string{}},
 	jaegerCollectorUrl:        {TYPESTRING, []string{}},
 }


### PR DESCRIPTION
Depends on https://github.com/cyberark/conjur-authn-k8s-client/pull/522

### Desired Outcome

Make log level configurable.
Currently there are only two options for logging: debug-logging on or off. There is a customer request to allow minimizing logs to only warnings or errors, with the option to enable info level logs as well. This will cut down on the amount of noise coming from secrets rotations, where the number of log messages will be amplified due to continual refresh.

### Implemented Changes

- Added new configuration option, "LOG_LEVEL" / "conjur.org/log-level"
  - Valid options are "debug", "info", "warn", "error"
 - Deprecated "DEBUG" / "conjur.org/debug-logging" configuration option

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2306

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
