### PR TITLE
Install GKE auth plugin

### DIFF
--- a/deploy/test/Dockerfile
+++ b/deploy/test/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 
 # Install Docker client
 RUN apt-get update -y && \
-    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget google-cloud-sdk-gke-gcloud-auth-plugin && \
     curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
     apt-get update && \


### PR DESCRIPTION
### Desired Outcome

Fix failing e2e tests due to the error message:
```
[2023-07-18T21:17:50.521Z] CRITICAL: ACTION REQUIRED: gke-gcloud-auth-plugin, which is needed for continued use of kubectl, was not found or is not executable. Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
[2023-07-18T21:17:51.880Z] Unable to connect to the server: getting credentials: exec: exec: "gke-gcloud-auth-plugin": executable file not found in $PATH
```

### Implemented Changes

Installs `google-cloud-sdk-gke-gcloud-auth-plugin` per the GKE documentation

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
