### PR TITLE
Upgrade base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.6.1] - 2023-07-27
 
-## [1.6.0] - 2023-07-19
+### Security
+- Updated go to 1.20, alpine to latest, and redhat UBI to ubi9 in main Dockerfile
+  [cyberark/secrets-provider-for-k8s#541](https://github.com/cyberark/secrets-provider-for-k8s/pull/541)
 
+## [1.6.0] - 2023-07-19
 ### Added
 - Log level is now configurable using the `LOG_LEVEL` environment variable or `conjur.org/log-level` annotation.
   The existing `DEBUG` environment variable and `conjur.org/debug-logging` annotation is deprecated and will be removed in a future update.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # =================== BASE BUILD LAYER ===================
 # this layer is used to prepare a common layer for both debug and release builds
-FROM golang:1.19 as secrets-provider-builder-base
+FROM golang:1.20 as secrets-provider-builder-base
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \
@@ -62,7 +62,7 @@ RUN go build -a -installsuffix cgo -gcflags="all=-N -l" -o secrets-provider ./cm
 
 # =================== BASE MAIN CONTAINER ===================
 # this layer is used to prepare a common layer for both debug and release containers
-FROM alpine:3.14 as secrets-provider-base
+FROM alpine:latest as secrets-provider-base
 MAINTAINER CyberArk Software Ltd.
 
 # Ensure openssl development libraries are always up to date
@@ -120,7 +120,7 @@ CMD ["/usr/local/bin/dlv",  \
      "/usr/local/bin/secrets-provider"]
 
 # =================== MAIN CONTAINER (REDHAT) ===================
-FROM registry.access.redhat.com/ubi8/ubi as secrets-provider-for-k8s-redhat
+FROM registry.access.redhat.com/ubi9/ubi as secrets-provider-for-k8s-redhat
 MAINTAINER CyberArk Software Ltd.
 
 ARG VERSION

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-e2e-test-runner"
 

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-junit-processor"
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secrets-provider-for-k8s-test-runner"
 


### PR DESCRIPTION
### Desired Outcome

Use the latest base images in building the container

### Implemented Changes

- Use go 1.20
- Use UBI9
- Use alpine:latest