### PR TITLE
E2E Test Migration for Tests 1.1 - 1.7

### DIFF
--- a/deploy/config/k8s/k8s-secret.yml
+++ b/deploy/config/k8s/k8s-secret.yml
@@ -6,6 +6,8 @@ type: Opaque
 stringData:
   conjur-map: |-
     secret: secrets/test_secret
+    ssh_key: secrets/ssh_key
+    json_object_secret: secrets/json_object_secret
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
     var_with_umlaut: secrets/umlaut

--- a/deploy/config/k8s/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/k8s/test-env-k8s-rotation.sh.yml
@@ -54,6 +54,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/config/k8s/test-env.sh.yml
+++ b/deploy/config/k8s/test-env.sh.yml
@@ -41,6 +41,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/config/openshift/k8s-secret.yml
+++ b/deploy/config/openshift/k8s-secret.yml
@@ -6,6 +6,8 @@ type: Opaque
 stringData:
   conjur-map: |-
     secret: secrets/test_secret
+    ssh_key: secrets/ssh_key
+    json_object_secret: secrets/json_object_secret
     var_with_spaces: secrets/var with spaces
     var_with_pluses: secrets/var+with+pluses
     var_with_umlaut: secrets/umlaut

--- a/deploy/config/openshift/test-env-k8s-rotation.sh.yml
+++ b/deploy/config/openshift/test-env-k8s-rotation.sh.yml
@@ -53,6 +53,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/config/openshift/test-env.sh.yml
+++ b/deploy/config/openshift/test-env.sh.yml
@@ -40,6 +40,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -31,6 +31,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-k8s-rotation.sh.yml
@@ -54,6 +54,16 @@ spec:
               secretKeyRef:
                 name: test-k8s-secret
                 key: secret
+          - name: SSH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: ssh_key
+          - name: JSON_OBJECT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-k8s-secret
+                key: json_object_secret
           - name: VARIABLE_WITH_SPACES_SECRET
             valueFrom:
               secretKeyRef:

--- a/deploy/policy/load_policies.sh
+++ b/deploy/policy/load_policies.sh
@@ -31,6 +31,8 @@ done
 # are testing in each test. We need them to have some value as both are required
 # in the pod
 conjur variable set -i secrets/test_secret -v "some-secret"
+conjur variable set -i "secrets/ssh_key" -v "\"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA879BJGYlPTLIuc9/R5MYiN4yc/YiCLcdBpSdzgK9Dt0Bkfe3rSz5cPm4wmehdE7GkVFXrBJ2YHqPLuM1yx1AUxIebpwlIl9f/aUHOts9eVnVh4NztPy0iSU/Sv0b2ODQQvcy2vYcujlorscl8JjAgfWsO3W4iGEe6QwBpVomcME8IU35v5VbylM9ORQa6wvZMVrPECBvwItTY8cPWH3MGZiK/74eHbSLKA4PY3gM4GHI450Nie16yggEg2aTQfWA1rry9JYWEoHS9pJ1dnLqZU3k/8OWgqJrilwSoC5rGjgp93iu0H8T6+mEHGRQe84Nk1y5lESSWIbn6P636Bl3uQ== your@email.com\""
+conjur variable set -i "secrets/json_object_secret" -v "\"{\"auths\":{\"someurl\":{\"auth\":\"sometoken=\"}}}\""
 conjur variable set -i "secrets/var with spaces" -v "some-secret"
 conjur variable set -i "secrets/var+with+pluses" -v "some-secret"
 conjur variable set -i "secrets/umlaut" -v "ÄäÖöÜü"

--- a/deploy/policy/templates/conjur-secrets.template.sh.yml
+++ b/deploy/policy/templates/conjur-secrets.template.sh.yml
@@ -8,6 +8,8 @@ cat << EOL
   body:
     - &variables
       - !variable test_secret
+      - !variable ssh_key
+      - !variable json_object_secret
       - !variable another_test_secret
       - !variable var with spaces
       - !variable var+with+pluses

--- a/e2e/k8s_test.go
+++ b/e2e/k8s_test.go
@@ -7,11 +7,83 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"strings"
+	"crypto/rand"
+	"encoding/base64"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
+
+func TestSSHKeysProvidedK8s(t *testing.T) {
+	f := features.New("ssh keys provided").
+		// Replaces TEST_ID_1.1_providing_ssh_keys_successfully
+		Assess("ssh key set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "|", "grep", "SSH_KEY"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), "\"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA879BJGYlPTLIuc9/R5MYiN4yc/YiCLcdBpSdzgK9Dt0Bkfe3rSz5cPm4wmehdE7GkVFXrBJ2YHqPLuM1yx1AUxIebpwlIl9f/aUHOts9eVnVh4NztPy0iSU/Sv0b2ODQQvcy2vYcujlorscl8JjAgfWsO3W4iGEe6QwBpVomcME8IU35v5VbylM9ORQa6wvZMVrPECBvwItTY8cPWH3MGZiK/74eHbSLKA4PY3gM4GHI450Nie16yggEg2aTQfWA1rry9JYWEoHS9pJ1dnLqZU3k/8OWgqJrilwSoC5rGjgp93iu0H8T6+mEHGRQe84Nk1y5lESSWIbn6P636Bl3uQ== your@email.com\"")
+		
+			return ctx
+		})
+	
+	testenv.Test(t, f.Feature())
+}
+
+func TestJsonObjectSecretProvidedK8s(t *testing.T) {
+	f := features.New("json object secret provided").
+		// Replaces TEST_ID_1.2_providing_json_object_secret_successfully
+		Assess("json object secret set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "|", "grep", "JSON_OBJECT_SECRET"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), "\"{\"auths\":{\"someurl\":{\"auth\":\"sometoken=\"}}}\"")
+		
+			return ctx
+		})
+	
+	testenv.Test(t, f.Feature())
+}
+
+
+func TestVariablesWithSpacesSecretProvidedK8s(t *testing.T) {
+	f := features.New("variables with spaces secret provided").
+		// Replaces TEST_ID_1.3_providing_variables_with_spaces_successfully
+		Assess("variables with spaces secret set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "|", "grep", "VARIABLE_WITH_SPACES_SECRET"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), "some-secret")
+
+			return ctx
+		})
+	
+	testenv.Test(t, f.Feature())
+}
+
+func TestVariablesWithPlusesSecretProvidedK8s(t *testing.T) {
+	f := features.New("variables with pluses secret provided").
+		// Replaces TEST_ID_1.4_providing_variables_with_pluses_successfully
+		Assess("variables with pluses secret set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "|", "grep", "VARIABLE_WITH_PLUSES_SECRET"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), "some-secret")
+		
+			return ctx
+		})
+	
+	testenv.Test(t, f.Feature())
+}
 
 func TestSecretsProvidedK8s(t *testing.T) {
 	f := features.New("secrets provided (K8s secrets mode)").
@@ -23,6 +95,62 @@ func TestSecretsProvidedK8s(t *testing.T) {
 			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
 
 			assert.Contains(t, stdout.String(), "ÄäÖöÜü")
+
+			return ctx
+		})
+
+	testenv.Test(t, f.Feature())
+}
+
+func TestVariablesWithBase64DecodingSecretProvidedK8s(t *testing.T) {
+	f := features.New("variables with base64 decoding secret provided").
+		// Replaces TEST_ID_1.6_providing_variables_with_base64_decoding_successfully
+		Assess("variables with base64 decoding secret set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "|", "grep", "VARIABLE_WITH_BASE64_SECRET"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), "secret-value")
+
+			return ctx
+		})
+
+	testenv.Test(t, f.Feature())
+}
+
+func TestLargeDecodedVariablesSecretProvidedK8s(t *testing.T) {
+	f := features.New("large decoded variables secret provided").
+		// Replaces TEST_ID_1.7_providing_large_decoded_variable_successfully
+		Assess("large decoded variable secret set correctly in pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// generate random string (> 65k characters) and base64 encode it
+			str := make([]byte, 65001)
+
+			_, err := rand.Read(str)
+			if err != nil {
+				return err
+			}
+
+			encodedStr := base64.StdEncoding.EncodeToString(str)
+
+			// set encoded value in conjur and reload template
+			_, err := SetConjurSecret(cfg.Client(), "secrets/encoded", encodedStr)
+			if err != nil {
+				return err
+			}
+
+			_, err := ReloadWithTemplate(cfg.Client(), K8sTemplate)
+			if err != nil {
+				return err
+			}
+
+			// check environment variable for expected value (the secret before encoding)
+			var stdout, stderr bytes.Buffer
+			command := []string{"printenv", "VARIABLE_WITH_BASE64_SECRET"}
+
+			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
+
+			assert.Contains(t, stdout.String(), str)
 
 			return ctx
 		})

--- a/e2e/k8s_test.go
+++ b/e2e/k8s_test.go
@@ -6,10 +6,10 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"testing"
-	"strings"
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -26,10 +26,10 @@ func TestSSHKeysProvidedK8s(t *testing.T) {
 			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
 
 			assert.Contains(t, stdout.String(), "\"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA879BJGYlPTLIuc9/R5MYiN4yc/YiCLcdBpSdzgK9Dt0Bkfe3rSz5cPm4wmehdE7GkVFXrBJ2YHqPLuM1yx1AUxIebpwlIl9f/aUHOts9eVnVh4NztPy0iSU/Sv0b2ODQQvcy2vYcujlorscl8JjAgfWsO3W4iGEe6QwBpVomcME8IU35v5VbylM9ORQa6wvZMVrPECBvwItTY8cPWH3MGZiK/74eHbSLKA4PY3gM4GHI450Nie16yggEg2aTQfWA1rry9JYWEoHS9pJ1dnLqZU3k/8OWgqJrilwSoC5rGjgp93iu0H8T6+mEHGRQe84Nk1y5lESSWIbn6P636Bl3uQ== your@email.com\"")
-		
+
 			return ctx
 		})
-	
+
 	testenv.Test(t, f.Feature())
 }
 
@@ -43,13 +43,12 @@ func TestJsonObjectSecretProvidedK8s(t *testing.T) {
 			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
 
 			assert.Contains(t, stdout.String(), "\"{\"auths\":{\"someurl\":{\"auth\":\"sometoken=\"}}}\"")
-		
+
 			return ctx
 		})
-	
+
 	testenv.Test(t, f.Feature())
 }
-
 
 func TestVariablesWithSpacesSecretProvidedK8s(t *testing.T) {
 	f := features.New("variables with spaces secret provided").
@@ -64,7 +63,7 @@ func TestVariablesWithSpacesSecretProvidedK8s(t *testing.T) {
 
 			return ctx
 		})
-	
+
 	testenv.Test(t, f.Feature())
 }
 
@@ -78,10 +77,10 @@ func TestVariablesWithPlusesSecretProvidedK8s(t *testing.T) {
 			RunCommandInSecretsProviderPod(cfg.Client(), command, &stdout, &stderr)
 
 			assert.Contains(t, stdout.String(), "some-secret")
-		
+
 			return ctx
 		})
-	
+
 	testenv.Test(t, f.Feature())
 }
 
@@ -128,20 +127,20 @@ func TestLargeDecodedVariablesSecretProvidedK8s(t *testing.T) {
 
 			_, err := rand.Read(str)
 			if err != nil {
-				return err
+				fmt.Errorf("error generating random string: %s", err)
 			}
 
 			encodedStr := base64.StdEncoding.EncodeToString(str)
 
 			// set encoded value in conjur and reload template
-			_, err := SetConjurSecret(cfg.Client(), "secrets/encoded", encodedStr)
+			err = SetConjurSecret(cfg.Client(), "secrets/encoded", encodedStr)
 			if err != nil {
-				return err
+				fmt.Errorf("error setting conjur secret: %s", err)
 			}
 
-			_, err := ReloadWithTemplate(cfg.Client(), K8sTemplate)
+			err = ReloadWithTemplate(cfg.Client(), K8sTemplate)
 			if err != nil {
-				return err
+				fmt.Errorf("error reloading secrets provider: %s", err)
 			}
 
 			// check environment variable for expected value (the secret before encoding)

--- a/go.sum
+++ b/go.sum
@@ -51,10 +51,10 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberark/conjur-api-go v0.11.1 h1:vjaMkw0geJsA+ikMM6UDLg4VLFQWKo/B0i9IWlOQ1f0=
 github.com/cyberark/conjur-api-go v0.11.1/go.mod h1:n1p46Hj9l8wkZjM17cVYdfcatyPboWyioLGlC0QszCs=
-github.com/cyberark/conjur-authn-k8s-client v0.25.2 h1:X6z4ldHEuGKycNUu6FBE6TzqADoLhHMTwTOWsaTF6No=
-github.com/cyberark/conjur-authn-k8s-client v0.25.2/go.mod h1:biD4y/VHqPWBzUk/nLoflQ/87f/RAJF4QJnuboKJHOY=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1141 h1:pXu+c6DZvDB0s2xXaZ5IkmoM8/YnhpocAzinn4CQNfM=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1141/go.mod h1:7pNmWZ/E4jv5cJuFWuXbzHpX6T44JfAPfciTWVxR9Ec=
+github.com/cyberark/conjur-authn-k8s-client v0.26.0 h1:iU+bstEsiCOTTp5dJxnbp2xcishacTM5iBRXFarxKsQ=
+github.com/cyberark/conjur-authn-k8s-client v0.26.0/go.mod h1:biD4y/VHqPWBzUk/nLoflQ/87f/RAJF4QJnuboKJHOY=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1174 h1:EtpQ514g3x1At/Gd/34DAsyhBOaFt5a1hKLPyprzJ+8=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-1174/go.mod h1:7pNmWZ/E4jv5cJuFWuXbzHpX6T44JfAPfciTWVxR9Ec=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### Desired Outcome

This pull request contains newly implemented tests that address Test IDs 1.1 - 1.7.

### Implemented Changes

- adds Tests 1.1 - 1.7 following the new E2E testing framework
- updates config files to contain environment variables that suffice the new E2E tests

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
