### PR TITLE
Load CONJUR_AUTHN_LOGIN in correct template

### DIFF
--- a/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
+++ b/deploy/dev/config/k8s/secrets-provider-init-container.sh.yml
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+CONJUR_AUTHN_LOGIN=${CONJUR_AUTHN_LOGIN:-"host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/*/*"}
+
 cat << EOL
 ---
 apiVersion: apps/v1
@@ -111,7 +113,7 @@ spec:
             value: "debug"
 
           - name: CONJUR_AUTHN_LOGIN
-            value: "host/conjur/authn-k8s/${AUTHENTICATOR_ID}/apps/${APP_NAMESPACE_NAME}/*/*"
+            value: ${CONJUR_AUTHN_LOGIN}
 
       imagePullSecrets:
         - name: dockerpullsecret

--- a/e2e/k8s_test.go
+++ b/e2e/k8s_test.go
@@ -169,7 +169,9 @@ func TestNoPermissionSecretProvidedK8s(t *testing.T) {
 
 			os.Setenv("CONJUR_AUTHN_LOGIN", loginURI)
 
-			// reload template with new login configuration
+			// In this case the pod will fail to start due to the expected error in Secrets Provider.
+			// Currently ReloadWithTemplate has a built-in 1 minute timeout for the pod to be 'Ready'
+			// We may be able to shorten or omit this timeout to speed up the test.
 			err := ReloadWithTemplate(cfg.Client(), K8sTemplate)
 			if err != nil {
 				fmt.Errorf("error reloading secrets provider: %s", err)


### PR DESCRIPTION
This pull request corrects the hard-coded value of `CONJUR_AUTHN_LOGIN` and implements Setup and Teardown functions within the tests.