### PR TITLE
improve error handling batch retrieve

### DIFF
--- a/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
+++ b/pkg/secrets/clients/conjur/conjur_secrets_retriever.go
@@ -2,7 +2,9 @@ package conjur
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cyberark/conjur-api-go/conjurapi"
@@ -18,6 +20,7 @@ import (
 )
 
 var fetchAllMaxSecrets = 500
+var errorRegex = regexp.MustCompile("CONJ00076E Variable .+:.+:(.+) is empty or not found")
 
 // SecretRetriever implements a Retrieve function that is capable of
 // authenticating with Conjur and retrieving multiple Conjur variables
@@ -106,7 +109,30 @@ func retrieveConjurSecrets(conjurClient ConjurClient, variableIDs []string) (map
 
 	retrievedSecretsByFullIDs, err := conjurClient.RetrieveBatchSecretsSafe(variableIDs)
 	if err != nil {
-		return nil, err
+		log.Error(err.Error())
+		//if there is one failed variable in batch request, whole request failed no data is returned.
+		//if batch failed we check the corrupted variableID, remove it from array ant try the batch request again
+		matches := errorRegex.FindStringSubmatch(err.Error())
+		if matches != nil {
+			if len(variableIDs) > 1 && len(matches) > 0 {
+				log.Debug("Removing failed %s variableID from list and try batch retrieve again", matches[1])
+				for i, v := range variableIDs {
+					if v == matches[1] {
+						variableIDs = append(variableIDs[:i], variableIDs[i+1:]...)
+						break
+					}
+				}
+				// try retrieveConjurSecrets again without bad variableIDs
+				// and join error from downstream call and return to upstream call
+				if retrievedSecrets, e := retrieveConjurSecrets(conjurClient, variableIDs); e != nil {
+					return retrievedSecrets, errors.Join(err, e)
+				} else {
+					return retrievedSecrets, err
+				}
+			}
+		} else if retrievedSecretsByFullIDs == nil || len(retrievedSecretsByFullIDs) == 0 {
+			return nil, err
+		}
 	}
 
 	// Normalise secret IDs from batch secrets back to <variable_id>

--- a/pkg/secrets/clients/conjur/conjur_secrets_retriever_test.go
+++ b/pkg/secrets/clients/conjur/conjur_secrets_retriever_test.go
@@ -58,6 +58,49 @@ func TestRetrieveConjurSecrets(t *testing.T) {
 	}
 }
 
+func TestRetrieveConjurSecretsWithBadVariableID(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		variableIDs     []string
+		expectedSecrets map[string][]byte
+		expectError     bool
+	}{
+		{
+			name: "Retrieve secrets successfully",
+			variableIDs: []string{
+				"secret1",
+				"notFound",
+				"secret3",
+			},
+			expectedSecrets: map[string][]byte{
+				"secret1": []byte("secret1"),
+				"secret3": []byte("secret3"),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mocks.ConjurMockClient{
+				Database: map[string]string{
+					"secret1": "secret1",
+					"secret3": "secret3",
+				},
+			}
+			secrets, err := retrieveConjurSecrets(client, tc.variableIDs)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedSecrets, secrets)
+		})
+	}
+}
+
 func TestRetrieveConjurSecretsAll(t *testing.T) {
 	testCases := []struct {
 		name                 string

--- a/pkg/secrets/clients/conjur/mocks/conjur_client.go
+++ b/pkg/secrets/clients/conjur/mocks/conjur_client.go
@@ -52,6 +52,9 @@ func (mc *ConjurMockClient) RetrieveBatchSecretsSafe(variableIDs []string) (map[
 				return secrets, nil
 			}
 
+			if secretID == "notFound" {
+				return nil, errors.New(fmt.Sprintf("CONJ00076E Variable %s is empty or not found", fmt.Sprintf("conjur:variable:%s", secretID)))
+			}
 			// Check if the secret exists in the mock Conjur DB
 			variableData, ok := mc.Database[secretID]
 			if !ok {


### PR DESCRIPTION
### Desired Outcome

Improve batch Conjur secrets retrieval, so because one (or more) bad secret, the entire operation won't fail. 

### Implemented Changes

When batch retrieve request fails, bad secret name is parsed from error message and it is removed from batch request. Next the batch request is repeated.

### Connected Issue/Story

DRAFT for:

https://github.com/cyberark/secrets-provider-for-k8s/issues/549


