### PR TITLE
leverage file temaplates with k8s-secret targets

### DIFF
--- a/pkg/log/messages/debug_messages.go
+++ b/pkg/log/messages/debug_messages.go
@@ -9,3 +9,4 @@ const CSPFK007D string = "CSPFK007D Kubernetes Secret '%s' has an invalid value 
 const CSPFK008D string = "CSPFK008D Kubernetes Secret '%s' has no '%s' data entry defined"
 const CSPFK009D string = "CSPFK009D Processing '%s' data entry value of Kubernetes Secret '%s'"
 const CSPFK010D string = "CSPFK010D Listed %d secrets from Conjur"
+const CSPFK011D string = "CSPFK011D Kubernetes Secret '%s' has no '%s' annotation defined"

--- a/pkg/secrets/clients/k8s/k8s_secrets_client.go
+++ b/pkg/secrets/clients/k8s/k8s_secrets_client.go
@@ -33,6 +33,10 @@ func UpdateK8sSecret(namespace string, secretName string, originalK8sSecret *v1.
 	// get K8s client object
 	kubeClient, _ := configK8sClient()
 
+	if originalK8sSecret.Data == nil {
+		originalK8sSecret.Data = map[string][]byte{}
+	}
+
 	for secretName, secretValue := range stringDataEntriesMap {
 		originalK8sSecret.Data[secretName] = secretValue
 	}

--- a/pkg/secrets/config/config.go
+++ b/pkg/secrets/config/config.go
@@ -247,6 +247,7 @@ func NewConfig(settings map[string]string) *Config {
 			k8sSecretsStr = strings.ReplaceAll(k8sSecretsStr, " ", "")
 			k8sSecretsArr = strings.Split(k8sSecretsStr, ",")
 		}
+		k8sSecretsArr = removeEmptyStrings(k8sSecretsArr)
 	}
 
 	retryCountLimitStr := settings[retryCountLimitKey]
@@ -417,4 +418,14 @@ func validRefreshInterval(intervalStr string, enableStr string, envAndAnnots map
 		}
 	}
 	return err
+}
+
+func removeEmptyStrings(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
 }

--- a/pkg/secrets/file_templates/secret_file_templates.go
+++ b/pkg/secrets/file_templates/secret_file_templates.go
@@ -1,0 +1,48 @@
+package filetemplates
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+const SecretGroupPrefix = "conjur.org/conjur-secrets."
+const SecretGroupFileTemplatePrefix = "conjur.org/secret-file-template."
+
+// Secret describes how Conjur secrets are represented in the file-template-rendering context.
+type Secret struct {
+	Alias string
+	Value string
+}
+
+// templateData describes the form in which data is presented to file templates
+type TemplateData struct {
+	SecretsArray []*Secret
+	SecretsMap   map[string]*Secret
+}
+
+func RenderFile(tpl *template.Template, tplData TemplateData) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	err := tpl.Execute(buf, tplData)
+	return buf, err
+}
+
+func GetTemplate(name string, secretsMap map[string]*Secret) *template.Template {
+
+	return template.New(name).Funcs(template.FuncMap{
+		// secret is a custom utility function for streamlined access to secret values.
+		// It panics for secrets aliases not specified on the group.
+		"secret": func(alias string) string {
+			v, ok := secretsMap[alias]
+			if ok {
+				return v.Value
+			}
+
+			// Panic in a template function is captured as an error
+			// when the template is executed.
+			panic(fmt.Sprintf("secret alias %q not present in specified secrets for group", alias))
+		},
+		"b64enc": b64encTemplateFunc,
+		"b64dec": b64decTemplateFunc,
+	})
+}

--- a/pkg/secrets/file_templates/secret_spec.go
+++ b/pkg/secrets/file_templates/secret_spec.go
@@ -1,4 +1,4 @@
-package pushtofile
+package filetemplates
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	maxConjurVarNameLen = 126
+	MaxConjurVarNameLen = 126
 )
 
 // SecretSpec specifies a secret to be retrieved from Conjur by defining
@@ -20,6 +20,14 @@ type SecretSpec struct {
 	Alias       string
 	Path        string
 	ContentType string
+}
+
+// SecretGroup incorporates common information about a secret group
+// that has been parsed from that secret group's Annotations.
+type SecretGroup struct {
+	Name         string
+	FileTemplate string
+	SecretSpecs  []SecretSpec
 }
 
 // MarshalYAML is a custom marshaller for SecretSpec.
@@ -112,11 +120,11 @@ func NewSecretSpecs(raw []byte) ([]SecretSpec, error) {
 	return secretSpecs, nil
 }
 
-func validateSecretPathsAndContents(secretSpecs []SecretSpec, groupName string) []error {
+func ValidateSecretPathsAndContents(secretSpecs []SecretSpec, groupName string) []error {
 
-	errors := validateSecretPaths(secretSpecs, groupName)
+	errors := ValidateSecretPaths(secretSpecs, groupName)
 
-	errs := validateSecretContents(secretSpecs, groupName)
+	errs := ValidateSecretContents(secretSpecs, groupName)
 	if errs != nil {
 		for _, err := range errs {
 			// Log the errors as warnings but allow it to proceed
@@ -126,7 +134,7 @@ func validateSecretPathsAndContents(secretSpecs []SecretSpec, groupName string) 
 	return errors
 }
 
-func validateSecretPaths(secretSpecs []SecretSpec, groupName string) []error {
+func ValidateSecretPaths(secretSpecs []SecretSpec, groupName string) []error {
 	var errors []error
 	for _, secretSpec := range secretSpecs {
 		if err := validateSecretPath(secretSpec.Path, groupName); err != nil {
@@ -136,7 +144,7 @@ func validateSecretPaths(secretSpecs []SecretSpec, groupName string) []error {
 	return errors
 }
 
-func validateSecretContents(secretSpecs []SecretSpec, groupName string) []error {
+func ValidateSecretContents(secretSpecs []SecretSpec, groupName string) []error {
 	var errors []error
 	for _, secretSpec := range secretSpecs {
 		if err := validateSecretContent(secretSpec.ContentType, groupName); err != nil {
@@ -169,9 +177,9 @@ func validateSecretPath(path, groupName string) error {
 
 	// The Conjur variable name (the last word in the Conjur variable path)
 	// must be no longer than 126 characters.
-	if len(varName) > maxConjurVarNameLen {
+	if len(varName) > MaxConjurVarNameLen {
 		return fmt.Errorf("Secret group %s: the Conjur variable name '%s' is longer than %d characters",
-			groupName, varName, maxConjurVarNameLen)
+			groupName, varName, MaxConjurVarNameLen)
 	}
 
 	return nil

--- a/pkg/secrets/file_templates/template_functions.go
+++ b/pkg/secrets/file_templates/template_functions.go
@@ -1,4 +1,4 @@
-package pushtofile
+package filetemplates
 
 import "encoding/base64"
 

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/log"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
 	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
+	"regexp"
+	"strings"
 
 	"github.com/cyberark/conjur-opentelemetry-tracer/pkg/trace"
 	"github.com/cyberark/secrets-provider-for-k8s/pkg/log/messages"
@@ -88,6 +88,8 @@ type K8sProvider struct {
 	// corresponding secret content. This is used to detect changes in
 	// secret content.
 	prevSecretsChecksums map[string]utils.Checksum
+	// Maps template groups to corresponding K8S Secret
+	secretsGroups map[string][]*filetemplates.SecretGroup
 }
 
 // K8sProviderConfig provides config specific to Kubernetes Secrets provider
@@ -147,6 +149,7 @@ func newProvider(
 		},
 		traceContext:         traceContext,
 		prevSecretsChecksums: map[string]utils.Checksum{},
+		secretsGroups:        map[string][]*filetemplates.SecretGroup{},
 	}
 }
 
@@ -158,7 +161,6 @@ func (p *K8sProvider) Provide() (bool, error) {
 	if err := p.retrieveRequiredK8sSecrets(tr); err != nil {
 		return false, p.log.recordedError(messages.CSPFK021E)
 	}
-
 	// Retrieve Conjur secrets for all K8s Secrets.
 	var updated bool
 	retrievedConjurSecrets, err := p.retrieveConjurSecrets(tr)
@@ -250,14 +252,49 @@ func (p *K8sProvider) retrieveRequiredK8sSecret(k8sSecretName string) error {
 	// field, if it exists. If the entry does not exist or has a null
 	// value, return an error.
 	conjurMapKey := config.ConjurMapKey
-	conjurSecretsYAML, entryExists := k8sSecret.Data[conjurMapKey]
-	if !entryExists {
+	conjurSecretsYAML, conjurMapExists := k8sSecret.Data[conjurMapKey]
+	if !conjurMapExists {
 		p.log.debug(messages.CSPFK008D, k8sSecretName, conjurMapKey)
-		return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
 	}
 	if len(conjurSecretsYAML) == 0 {
 		p.log.debug(messages.CSPFK006D, k8sSecretName, conjurMapKey)
+	}
+
+	var secretGroups []*filetemplates.SecretGroup
+	//look for "conjur.org/conjur-secrets.*" annotations
+	for annotationName, annotationValue := range k8sSecret.Annotations {
+		if strings.HasPrefix(annotationName, filetemplates.SecretGroupPrefix) {
+			groupName := strings.TrimPrefix(annotationName, filetemplates.SecretGroupPrefix)
+			//now for given group look for its template annotation "conjur.org/secret-file-template.*"
+			if _, tplExists := k8sSecret.Annotations[filetemplates.SecretGroupFileTemplatePrefix+groupName]; tplExists {
+				secretSpecs, err := filetemplates.NewSecretSpecs([]byte(annotationValue))
+				if err != nil {
+					err = fmt.Errorf(`unable to create secret specs from annotation "%s": %s`, filetemplates.SecretGroupFileTemplatePrefix+groupName, err)
+					return err
+				}
+				secretGroup := &filetemplates.SecretGroup{
+					Name:        groupName,
+					SecretSpecs: secretSpecs,
+				}
+				secretGroups = append(secretGroups, secretGroup)
+			} else {
+				p.log.warn(messages.CSPFK011D, k8sSecretName, filetemplates.SecretGroupFileTemplatePrefix+groupName)
+			}
+		}
+	}
+
+	if len(secretGroups) < 1 {
+		p.log.debug("No %s annotation will be used for %s secret", "conjur.org/conjur-secrets", k8sSecret.Name)
+	} else {
+		p.secretsGroups[k8sSecretName] = secretGroups
+	}
+
+	// At least ne of "conjur-map" field or "conjur.org/conjur-secrets.*" annotation  must be defined.
+	// If it is not, error is returned
+	if (!conjurMapExists || len(conjurSecretsYAML) == 0) && (len(secretGroups) < 1) {
+		p.log.logError("At least on of %s data entry or %s annotations must defined", conjurMapKey, "conjur.org/conjur-secrets.* & conjur.org/secret-file-template.*")
 		return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
+		//return p.log.recordedError("At least on of %s or %s must defined", conjurMapKey+" data entry", conjurVariablesAnnotationName+" annotation")
 	}
 
 	// Parse the YAML-formatted Conjur secrets mapping that has been
@@ -270,13 +307,15 @@ func (p *K8sProvider) retrieveRequiredK8sSecret(k8sSecretName string) error {
 // that has been retrieved from a K8s Secret.
 func (p *K8sProvider) parseConjurSecretsYAML(secretsYAML []byte, k8sSecretName string) error {
 	conjurMap := map[string]interface{}{}
-	if err := yaml.Unmarshal(secretsYAML, &conjurMap); err != nil {
-		p.log.debug(messages.CSPFK007D, k8sSecretName, config.ConjurMapKey, err.Error())
-		return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
-	}
-	if len(conjurMap) == 0 {
-		p.log.debug(messages.CSPFK007D, k8sSecretName, config.ConjurMapKey, "value is empty")
-		return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
+	if len(secretsYAML) > 0 {
+		if err := yaml.Unmarshal(secretsYAML, &conjurMap); err != nil {
+			p.log.debug(messages.CSPFK007D, k8sSecretName, config.ConjurMapKey, err.Error())
+			return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
+		}
+		if len(conjurMap) == 0 {
+			p.log.debug(messages.CSPFK007D, k8sSecretName, config.ConjurMapKey, "value is empty")
+			return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
+		}
 	}
 	return p.refreshUpdateDestinations(conjurMap, k8sSecretName)
 }
@@ -289,9 +328,9 @@ func (p *K8sProvider) parseConjurSecretsYAML(secretsYAML []byte, k8sSecretName s
 func (p *K8sProvider) refreshUpdateDestinations(conjurMap map[string]interface{}, k8sSecretName string) error {
 	for secretName, contents := range conjurMap {
 		switch value := contents.(type) {
-		case string:
+		case string: //in that case contents is varID
 			dest := updateDestination{k8sSecretName, secretName, "text"}
-			p.secretsState.updateDestinations[value] = append(p.secretsState.updateDestinations[value], dest)
+			p.secretsState.updateDestinations[value] = appendDestination(p.secretsState.updateDestinations[value], dest)
 		case map[interface{}]interface{}:
 			varId, ok := value["id"].(string)
 			if !ok || varId == "" {
@@ -301,11 +340,11 @@ func (p *K8sProvider) refreshUpdateDestinations(conjurMap map[string]interface{}
 			contentType, ok := value["content-type"].(string)
 			if ok && contentType == "base64" {
 				dest := updateDestination{k8sSecretName, secretName, "base64"}
-				p.secretsState.updateDestinations[varId] = append(p.secretsState.updateDestinations[varId], dest)
+				p.secretsState.updateDestinations[varId] = appendDestination(p.secretsState.updateDestinations[varId], dest)
 				p.log.info(messages.CSPFK022I, secretName, k8sSecretName)
 			} else {
 				dest := updateDestination{k8sSecretName, secretName, "text"}
-				p.secretsState.updateDestinations[varId] = append(p.secretsState.updateDestinations[varId], dest)
+				p.secretsState.updateDestinations[varId] = appendDestination(p.secretsState.updateDestinations[varId], dest)
 			}
 		default:
 			return p.log.recordedError(messages.CSPFK028E, k8sSecretName)
@@ -314,10 +353,23 @@ func (p *K8sProvider) refreshUpdateDestinations(conjurMap map[string]interface{}
 	return nil
 }
 
+// appendDestination is helper function for slice of updateDestination objects
+// If not already exists, append new destination to list
+func appendDestination(dests []updateDestination, dest updateDestination) []updateDestination {
+	for _, destt := range dests {
+		if destt.k8sSecretName == dest.k8sSecretName && destt.secretName == dest.k8sSecretName {
+			return dests
+		}
+	}
+	return append(dests, dest)
+}
+
 func (p *K8sProvider) listConjurSecretsToFetch() ([]string, error) {
 	updateDests := p.secretsState.updateDestinations
-	if len(updateDests) == 0 {
-		return nil, p.log.recordedError(messages.CSPFK025E)
+
+	if (updateDests == nil || len(updateDests) == 0) && len(p.secretsGroups) < 1 {
+		p.log.debug("No secrets to update")
+		return make([]string, 0), nil
 	}
 
 	// Gather the set of variable IDs for all secrets that need to be
@@ -331,7 +383,33 @@ func (p *K8sProvider) listConjurSecretsToFetch() ([]string, error) {
 
 		variableIDs = append(variableIDs, key)
 	}
+
+	for _, secretGroups := range p.secretsGroups {
+		for _, secretGroup := range secretGroups {
+			for _, secretSpec := range secretGroup.SecretSpecs {
+				if contains(variableIDs, secretSpec.Path) {
+					continue
+				}
+				variableIDs = append(variableIDs, secretSpec.Path)
+			}
+		}
+	}
+
+	if len(variableIDs) == 0 {
+		return nil, p.log.recordedError(messages.CSPFK025E)
+	}
+	p.log.debug("List of Conjur Secrets to fetch %s", updateDests)
+
 	return variableIDs, nil
+}
+
+func contains(elems []string, v string) bool {
+	for _, s := range elems {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *K8sProvider) retrieveConjurSecrets(tracer trace.Tracer) (map[string][]byte, error) {
@@ -359,10 +437,11 @@ func (p *K8sProvider) updateRequiredK8sSecrets(
 	spanCtx, span := tracer.Start(p.traceContext, "Update K8s Secrets")
 	defer span.End()
 
-	newSecretData := p.createSecretData(conjurSecrets)
+	newSecretsDataMap := p.createSecretData(conjurSecrets)
+	newSecretsDataMap = p.createGroupTemplateSecretData(conjurSecrets, newSecretsDataMap)
 
 	// Update K8s Secrets with the retrieved Conjur secrets
-	for k8sSecretName, secretData := range newSecretData {
+	for k8sSecretName, secretData := range newSecretsDataMap {
 		_, childSpan := tracer.Start(spanCtx, "Update K8s Secret")
 		defer childSpan.End()
 		b := new(bytes.Buffer)
@@ -484,8 +563,72 @@ func (p *K8sProvider) createSecretData(conjurSecrets map[string][]byte) map[stri
 			}
 		}
 	}
-
 	return secretData
+}
+
+// createGroupTemplateSecretData creates a map of entries to be added to the 'Data' fields
+// of each K8s Secret. Data fields are created from group secret variables and rendered corresponding group template filled with secret values retrieved from Conjur,
+// If a secret has a 'base64' content type, the resulting secret value will be decoded.
+func (p *K8sProvider) createGroupTemplateSecretData(conjurSecrets map[string][]byte,
+	newSecretsDataMap map[string]map[string][]byte) map[string]map[string][]byte {
+
+	for k8sSecretName, secretGroups := range p.secretsGroups {
+		//group for k8s secret
+		secretsByGroup := map[string][]*filetemplates.Secret{}
+
+		for _, secretGroup := range secretGroups {
+			for _, secSpec := range secretGroup.SecretSpecs {
+				bValue, ok := conjurSecrets[secSpec.Path]
+				if !ok {
+					p.log.logError("Value for '%s' group alias '%s' not fetched from Conjur", secretGroup.Name, secSpec.Alias)
+					bValue = []byte{}
+				}
+
+				//add retrieved value for group
+				secretsByGroup[secretGroup.Name] = append(
+					secretsByGroup[secretGroup.Name],
+					&filetemplates.Secret{
+						Alias: secSpec.Alias,
+						Value: string(bValue),
+					})
+			}
+		}
+
+		//render every group
+		for groupName, sec := range secretsByGroup {
+
+			secretsMap := map[string]*filetemplates.Secret{}
+			for _, s := range sec {
+				secretsMap[s.Alias] = s
+			}
+
+			groupTemplate := p.secretsState.originalK8sSecrets[k8sSecretName].
+				Annotations[filetemplates.SecretGroupFileTemplatePrefix+groupName]
+			tpl, err := filetemplates.GetTemplate(groupName, secretsMap).Parse(groupTemplate)
+			if err != nil {
+				p.log.logError("Unable to get template for %s group in %s secret: %s", groupName, k8sSecretName, err.Error())
+				continue
+			}
+
+			// Render the secret file content
+			tplData := filetemplates.TemplateData{
+				SecretsArray: sec,
+				SecretsMap:   secretsMap,
+			}
+			fileContent, err := filetemplates.RenderFile(tpl, tplData)
+			if err != nil {
+				p.log.logError("Failed render template for %s group in %s secret: %s", groupName, k8sSecretName, err.Error())
+				continue
+			}
+
+			if newSecretsDataMap[k8sSecretName] == nil {
+				newSecretsDataMap[k8sSecretName] = map[string][]byte{}
+			}
+			//set rendered template into secret with groupName as a key
+			newSecretsDataMap[k8sSecretName][groupName] = fileContent.Bytes()
+		}
+	}
+	return newSecretsDataMap
 }
 
 func normalizeK8sSecretName(name string) string {

--- a/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
+++ b/pkg/secrets/k8s_secrets_storage/provide_conjur_secrets_test.go
@@ -170,6 +170,7 @@ func TestProvide(t *testing.T) {
 	testCases := []struct {
 		desc                   string
 		k8sSecrets             k8sStorageMocks.K8sSecrets
+		annotations            map[string]map[string]string
 		requiredSecrets        []string
 		denyConjurRetrieve     bool
 		denyK8sRetrieve        bool
@@ -189,6 +190,30 @@ func TestProvide(t *testing.T) {
 				assertSecretsUpdated(
 					expectedK8sSecrets{
 						"k8s-secret1": {"secret1": "secret-value1"},
+					},
+					expectedMissingValues{},
+					false,
+				),
+			},
+		},
+		{
+			desc: "Happy path group template, existing k8s Secret with existing Conjur secret",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {"secret1": "conjur/var/path1"},
+				},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.secret2":       "- var: conjur/var/path2",
+					"conjur.org/secret-file-template.secret2": "{{ secret \"var\" }}",
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {"secret1": "secret-value1", "secret2": "secret-value2"},
 					},
 					expectedMissingValues{},
 					false,
@@ -221,6 +246,54 @@ func TestProvide(t *testing.T) {
 						},
 						"k8s-secret2": {
 							"secret3": "secret-value3",
+							"secret4": "secret-value4",
+						},
+					},
+					expectedMissingValues{
+						"k8s-secret1": {"secret-value3", "secret-value4"},
+						"k8s-secret2": {"secret-value1", "secret-value2"},
+					},
+					false,
+				),
+			},
+		},
+		{
+			desc: "Happy path with group template, 2 existing k8s Secrets with 2 existing Conjur secrets",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {
+						"secret1": "conjur/var/path1",
+					},
+				},
+				"k8s-secret2": {
+					"conjur-map": {
+						"secret3": "conjur/var/path3",
+						"secret4": "conjur/var/path4",
+					},
+				},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.secret2":       "- var: conjur/var/path2",
+					"conjur.org/secret-file-template.secret2": "template-secret2: {{ secret \"var\" }}",
+				},
+				"k8s-secret2": {
+					"conjur.org/conjur-secrets.secret3":       "- var: conjur/var/path3",
+					"conjur.org/secret-file-template.secret3": "template-secret3: \n{{ secret \"var\" }}",
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1", "k8s-secret2"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {
+							"secret1": "secret-value1",
+							"secret2": "template-secret2: " +
+								"secret-value2",
+						},
+						"k8s-secret2": {
+							"secret3": "template-secret3: " +
+								"\nsecret-value3",
 							"secret4": "secret-value4",
 						},
 					},
@@ -339,6 +412,28 @@ func TestProvide(t *testing.T) {
 			},
 		},
 		{
+			desc: "Happy path with group template, secret with umlaut characters",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.secret1":       "- var: conjur/var/umlaut",
+					"conjur.org/secret-file-template.secret1": "this is \n{{ secret \"var\" }} \n data",
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {"secret1": "this is \nÄäÖöÜü \n data"},
+					},
+					expectedMissingValues{},
+					false,
+				),
+			},
+		},
+		{
 			desc: "Happy path, binary secret",
 			k8sSecrets: k8sStorageMocks.K8sSecrets{
 				"k8s-secret1": {
@@ -350,6 +445,28 @@ func TestProvide(t *testing.T) {
 				assertSecretsUpdated(
 					expectedK8sSecrets{
 						"k8s-secret1": {"secret1": "\xf0\xff\x4a\xc3"},
+					},
+					expectedMissingValues{},
+					false,
+				),
+			},
+		},
+		{
+			desc: "Happy path with template group, binary secret",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.secret1":       "- var: conjur/var/binary",
+					"conjur.org/secret-file-template.secret1": "this is binary: {{ secret \"var\" }}",
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {"secret1": "this is binary: \xf0\xff\x4a\xc3"},
 					},
 					expectedMissingValues{},
 					false,
@@ -399,6 +516,54 @@ func TestProvide(t *testing.T) {
 				),
 				assertLogged(true, "info", messages.CSPFK022I, "test-decoding", "k8s-secret1"),
 				assertLogged(true, "info", messages.CSPFK022I, "test-decoding2", "k8s-secret1"),
+				assertLogged(false, "info", messages.CSPFK022I, "test-still-encoded", "k8s-secret2"),
+				assertLogged(false, "info", messages.CSPFK022I, "test-still-encoded2", "k8s-secret2"),
+			},
+		},
+		{
+			desc: "Happy path with template group, encoded secrets with valid content-type",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {
+						"test-decoding": map[string]interface{}{
+							"id":           "conjur/var/encoded1",
+							"content-type": "base64",
+						},
+					},
+				},
+				"k8s-secret2": {
+					"conjur-map": {
+						"test-still-encoded": "conjur/var/encoded1",
+					},
+				},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.test-decoding2":       "- var: conjur/var/encoded2",
+					"conjur.org/secret-file-template.test-decoding2": "this is decoded base64: {{ secret \"var\" | b64dec }}",
+				},
+				"k8s-secret2": {
+					"conjur.org/conjur-secrets.test-still-encoded2":       "- var: conjur/var/encoded2",
+					"conjur.org/secret-file-template.test-still-encoded2": "this is encoded base64: {{ secret \"var\" }}",
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1", "k8s-secret2"},
+			asserts: []assertFunc{
+				assertSecretsUpdated(
+					expectedK8sSecrets{
+						"k8s-secret1": {
+							"test-decoding":  "decoded-value-1",
+							"test-decoding2": "this is decoded base64: decoded-value-2",
+						},
+						"k8s-secret2": {
+							"test-still-encoded":  "ZGVjb2RlZC12YWx1ZS0x",
+							"test-still-encoded2": "this is encoded base64: ZGVjb2RlZC12YWx1ZS0y",
+						},
+					},
+					expectedMissingValues{},
+					false,
+				),
+				assertLogged(true, "info", messages.CSPFK022I, "test-decoding", "k8s-secret1"),
 				assertLogged(false, "info", messages.CSPFK022I, "test-still-encoded", "k8s-secret2"),
 				assertLogged(false, "info", messages.CSPFK022I, "test-still-encoded2", "k8s-secret2"),
 			},
@@ -473,6 +638,29 @@ func TestProvide(t *testing.T) {
 							"content-type": "text",
 						},
 					},
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertErrorLogged(messages.CSPFK037E, "test-decoding", "k8s-secret1"),
+			},
+		},
+		{
+			desc: "Empty var ID in template group throws error",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"conjur-map": {
+						"test-decoding": map[string]interface{}{
+							"id":           "",
+							"content-type": "text",
+						},
+					},
+				},
+			},
+			annotations: map[string]map[string]string{
+				"k8s-secret1": {
+					"conjur.org/conjur-secrets.test-decoding":       "- var: \"\"",
+					"conjur.org/secret-file-template.test-decoding": "{{ secret \"var\" }}",
 				},
 			},
 			requiredSecrets: []string{"k8s-secret1"},
@@ -576,6 +764,20 @@ func TestProvide(t *testing.T) {
 			asserts: []assertFunc{
 				assertErrorLogged(messages.CSPFK028E, "k8s-secret1"),
 				assertErrorContains(messages.CSPFK021E, false),
+			},
+		},
+		{
+			desc: "K8s secret has no 'conjur-map' entry or group template",
+			k8sSecrets: k8sStorageMocks.K8sSecrets{
+				"k8s-secret1": {
+					"foobar": {"foo": "bar"},
+				},
+			},
+			requiredSecrets: []string{"k8s-secret1"},
+			asserts: []assertFunc{
+				assertErrorLogged(messages.CSPFK028E, "k8s-secret1"),
+				assertErrorContains(messages.CSPFK021E, false),
+				assertErrorLogged("At least on of %s data entry or %s annotations must defined", "conjur-map", "conjur.org/conjur-secrets.* & conjur.org/secret-file-template.*"),
 			},
 		},
 		{
@@ -829,7 +1031,7 @@ func TestProvide(t *testing.T) {
 				tc.denyK8sUpdate)
 
 			for secretName, secretData := range tc.k8sSecrets {
-				mocks.kubeClient.AddSecret(secretName, secretData)
+				mocks.kubeClient.AddSecret(secretName, tc.annotations[secretName], secretData)
 			}
 			provider := mocks.newProvider(tc.requiredSecrets)
 
@@ -864,7 +1066,7 @@ func TestSecretsContentChanges(t *testing.T) {
 	mocks := newTestMocks()
 	mocks.setPermissions(denyConjurRetrieve, denyK8sRetrieve, denyK8sUpdate)
 	for secretName, secretData := range k8sSecrets {
-		mocks.kubeClient.AddSecret(secretName, secretData)
+		mocks.kubeClient.AddSecret(secretName, map[string]string{}, secretData)
 	}
 	provider := mocks.newProvider(requiredSecrets)
 	update, err := provider.Provide()
@@ -1143,7 +1345,7 @@ func TestProvideSanitization(t *testing.T) {
 		provider := mocks.newProvider(tc.requiredSecrets)
 		provider.sanitizeEnabled = tc.sanitizeEnabled
 		for secretName, secretData := range tc.k8sSecrets {
-			mocks.kubeClient.AddSecret(secretName, secretData)
+			mocks.kubeClient.AddSecret(secretName, map[string]string{}, secretData)
 		}
 		updated, err := provider.Provide()
 		assert.NoError(t, err, tc.desc)

--- a/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
+++ b/pkg/secrets/pushtofile/provide_conjur_secrets_test.go
@@ -3,6 +3,7 @@ package pushtofile
 import (
 	"context"
 	"fmt"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
 	"os"
 	"testing"
 
@@ -33,7 +34,7 @@ func secretGroups(filePath string) []*SecretGroup {
 			FilePath:        filePath,
 			FileFormat:      "yaml",
 			FilePermissions: 123,
-			SecretSpecs: []SecretSpec{
+			SecretSpecs: []filetemplates.SecretSpec{
 				{
 					Alias: "password",
 					Path:  "path1",
@@ -67,7 +68,7 @@ func TestNewProvider(t *testing.T) {
 					FileTemplate:    "",
 					FileFormat:      "yaml",
 					FilePermissions: defaultFilePermissions,
-					SecretSpecs: []SecretSpec{
+					SecretSpecs: []filetemplates.SecretSpec{
 						{
 							Alias:       "password",
 							Path:        "path1",

--- a/pkg/secrets/pushtofile/secret-group_utils_test.go
+++ b/pkg/secrets/pushtofile/secret-group_utils_test.go
@@ -2,6 +2,7 @@ package pushtofile
 
 import (
 	"bytes"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
 	"io"
 	"os"
 )
@@ -18,7 +19,7 @@ type pushToWriterArgs struct {
 	writer        io.Writer
 	groupName     string
 	groupTemplate string
-	groupSecrets  []*Secret
+	groupSecrets  []*filetemplates.Secret
 }
 
 type pushToWriterSpy struct {
@@ -32,7 +33,7 @@ func (spy *pushToWriterSpy) Call(
 	writer io.Writer,
 	groupName string,
 	groupTemplate string,
-	groupSecrets []*Secret,
+	groupSecrets []*filetemplates.Secret,
 ) (bool, error) {
 	spy._calls++
 	// This is to ensure the spy is only ever used once!

--- a/pkg/secrets/pushtofile/secret_spec_test.go
+++ b/pkg/secrets/pushtofile/secret_spec_test.go
@@ -2,6 +2,7 @@ package pushtofile
 
 import (
 	"fmt"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
 	"strings"
 	"testing"
 
@@ -16,18 +17,18 @@ const (
 type secretsSpecTestCase struct {
 	description string
 	contents    string
-	assert      func(t *testing.T, result []SecretSpec, err error)
+	assert      func(t *testing.T, result []filetemplates.SecretSpec, err error)
 }
 
 func (tc secretsSpecTestCase) Run(t *testing.T) {
 	t.Run(tc.description, func(t *testing.T) {
-		secretsSpecs, err := NewSecretSpecs([]byte(tc.contents))
+		secretsSpecs, err := filetemplates.NewSecretSpecs([]byte(tc.contents))
 		tc.assert(t, secretsSpecs, err)
 	})
 }
 
-func assertGoodSecretSpecs(expectedResult []SecretSpec) func(*testing.T, []SecretSpec, error) {
-	return func(t *testing.T, result []SecretSpec, err error) {
+func assertGoodSecretSpecs(expectedResult []filetemplates.SecretSpec) func(*testing.T, []filetemplates.SecretSpec, error) {
+	return func(t *testing.T, result []filetemplates.SecretSpec, err error) {
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -48,7 +49,7 @@ var secretsSpecTestCases = []secretsSpecTestCase{
 - admin-password: dev/openshift/password
 `,
 		assert: assertGoodSecretSpecs(
-			[]SecretSpec{
+			[]filetemplates.SecretSpec{
 				{
 					Alias:       "api-url",
 					Path:        "dev/openshift/api-url",
@@ -68,9 +69,9 @@ var secretsSpecTestCases = []secretsSpecTestCase{
 admin-password: dev/openshift/password
 another-password: dev/openshift/password
 `,
-		assert: func(t *testing.T, result []SecretSpec, err error) {
+		assert: func(t *testing.T, result []filetemplates.SecretSpec, err error) {
 			assert.Contains(t, err.Error(), "cannot unmarshal")
-			assert.Contains(t, err.Error(), "into []pushtofile.SecretSpec")
+			assert.Contains(t, err.Error(), "into []filetemplates.SecretSpec")
 		},
 	},
 	{
@@ -80,7 +81,7 @@ another-password: dev/openshift/password
   another-admin-password: dev/openshift/password
 - dev/openshift/api-url
 `,
-		assert: func(t *testing.T, result []SecretSpec, err error) {
+		assert: func(t *testing.T, result []filetemplates.SecretSpec, err error) {
 			assert.Contains(t, err.Error(), "expected a")
 			assert.Contains(t, err.Error(), "on line 2")
 		},
@@ -92,7 +93,7 @@ another-password: dev/openshift/password
 - key: 
     inner-key: inner-value
 `,
-		assert: func(t *testing.T, result []SecretSpec, err error) {
+		assert: func(t *testing.T, result []filetemplates.SecretSpec, err error) {
 			assert.Contains(t, err.Error(), "expected a")
 			assert.Contains(t, err.Error(), "on line 3")
 		},
@@ -104,7 +105,7 @@ another-password: dev/openshift/password
 - api-password: dev/openshift/api-password
 - - list item
 `,
-		assert: func(t *testing.T, result []SecretSpec, err error) {
+		assert: func(t *testing.T, result []filetemplates.SecretSpec, err error) {
 			assert.Contains(t, err.Error(), "expected a")
 			assert.Contains(t, err.Error(), "on line 4")
 		},
@@ -116,7 +117,7 @@ another-password: dev/openshift/password
   content-type: text
 `,
 		assert: assertGoodSecretSpecs(
-			[]SecretSpec{
+			[]filetemplates.SecretSpec{
 				{
 					Alias:       "dev",
 					Path:        "dev/openshift/api-url",
@@ -132,7 +133,7 @@ another-password: dev/openshift/password
   content-type: base64
 `,
 		assert: assertGoodSecretSpecs(
-			[]SecretSpec{
+			[]filetemplates.SecretSpec{
 				{
 					Alias:       "dev",
 					Path:        "dev/openshift/api-url",
@@ -145,7 +146,7 @@ another-password: dev/openshift/password
 		description: "fetch all",
 		contents:    "*",
 		assert: assertGoodSecretSpecs(
-			[]SecretSpec{
+			[]filetemplates.SecretSpec{
 				{
 					Path:        "*",
 					Alias:       "*",
@@ -161,7 +162,7 @@ another-password: dev/openshift/password
   content-type: base64
 `,
 		assert: assertGoodSecretSpecs(
-			[]SecretSpec{
+			[]filetemplates.SecretSpec{
 				{
 					Path:        "*",
 					Alias:       "*",
@@ -179,7 +180,7 @@ func TestNewSecretSpecs(t *testing.T) {
 }
 
 func TestValidateSecretSpecPaths(t *testing.T) {
-	maxLenConjurVarName := strings.Repeat("a", maxConjurVarNameLen)
+	maxLenConjurVarName := strings.Repeat("a", filetemplates.MaxConjurVarNameLen)
 
 	type assertFunc func(*testing.T, []error, string)
 
@@ -229,7 +230,7 @@ func TestValidateSecretSpecPaths(t *testing.T) {
 			validConjurPath1 + "/" + maxLenConjurVarName + "a",
 			validConjurPath2,
 			assertErrorsContain(fmt.Sprintf(
-				"is longer than %d characters", maxConjurVarNameLen)),
+				"is longer than %d characters", filetemplates.MaxConjurVarNameLen)),
 		}, {
 			"Two Conjur paths with trailing '/'",
 			validConjurPath1 + "/",
@@ -240,13 +241,13 @@ func TestValidateSecretSpecPaths(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Set up test case
-		secretSpecs := []SecretSpec{
+		secretSpecs := []filetemplates.SecretSpec{
 			{Alias: "foo", Path: tc.path1},
 			{Alias: "bar", Path: tc.path2},
 		}
 
 		// Run test case
-		err := validateSecretPaths(secretSpecs, "some-group-name")
+		err := filetemplates.ValidateSecretPaths(secretSpecs, "some-group-name")
 
 		// Check result
 		tc.assert(t, err, tc.description)
@@ -306,13 +307,13 @@ func TestValidateSecretSpecContents(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Set up test case
-		secretSpecs := []SecretSpec{
+		secretSpecs := []filetemplates.SecretSpec{
 			{Alias: "foo", Path: validConjurPath1, ContentType: tc.Content1},
 			{Alias: "bar", Path: validConjurPath1, ContentType: tc.Content2},
 		}
 
 		// Run test case
-		err := validateSecretContents(secretSpecs, "some-group-name")
+		err := filetemplates.ValidateSecretContents(secretSpecs, "some-group-name")
 
 		// Check result
 		tc.assert(t, err, tc.description)

--- a/pkg/secrets/pushtofile/standard_templates.go
+++ b/pkg/secrets/pushtofile/standard_templates.go
@@ -1,6 +1,9 @@
 package pushtofile
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
+)
 
 type standardTemplate struct {
 	template      string
@@ -28,7 +31,7 @@ var standardTemplates = map[string]standardTemplate{
 // standard template exists and validating secret spec aliases against it
 func FileTemplateForFormat(
 	fileFormat string,
-	secretSpecs []SecretSpec,
+	secretSpecs []filetemplates.SecretSpec,
 ) (string, error) {
 	stdTemplate, ok := standardTemplates[fileFormat]
 	if !ok {

--- a/pkg/secrets/pushtofile/standard_templates_test.go
+++ b/pkg/secrets/pushtofile/standard_templates_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cyberark/secrets-provider-for-k8s/pkg/secrets/file_templates"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +38,7 @@ var standardTemplateTestCases = []pushToWriterTestCase{
 	{
 		description: "json",
 		template:    standardTemplates["json"].template,
-		secrets: []*Secret{
+		secrets: []*filetemplates.Secret{
 			{Alias: "alias 1", Value: "secret value 1"},
 			{"alias 2", "secret value 2"},
 		},
@@ -46,7 +47,7 @@ var standardTemplateTestCases = []pushToWriterTestCase{
 	{
 		description: "yaml",
 		template:    standardTemplates["yaml"].template,
-		secrets: []*Secret{
+		secrets: []*filetemplates.Secret{
 			{Alias: "alias 1", Value: "secret value 1"},
 			{"alias 2", "secret value 2"},
 		},
@@ -56,7 +57,7 @@ var standardTemplateTestCases = []pushToWriterTestCase{
 	{
 		description: "dotenv",
 		template:    standardTemplates["dotenv"].template,
-		secrets: []*Secret{
+		secrets: []*filetemplates.Secret{
 			{Alias: "alias1", Value: "secret value 1"},
 			{"alias2", "secret value 2"},
 		},
@@ -66,7 +67,7 @@ alias2="secret value 2"`),
 	{
 		description: "properties",
 		template:    standardTemplates["properties"].template,
-		secrets: []*Secret{
+		secrets: []*filetemplates.Secret{
 			{Alias: "alias.1", Value: "secret value 1"},
 			{"alias2", "secret value 2"},
 		},
@@ -76,7 +77,7 @@ alias2="secret value 2"`),
 	{
 		description: "bash",
 		template:    standardTemplates["bash"].template,
-		secrets: []*Secret{
+		secrets: []*filetemplates.Secret{
 			{Alias: "alias1", Value: "secret value 1"},
 			{"alias2", "secret value 2"},
 		},
@@ -103,7 +104,7 @@ func (tc *aliasCharTestCase) Run(t *testing.T, fileFormat string) {
 		desc := fmt.Sprintf("%s file format, key containing %s character",
 			fileFormat, tc.description)
 		alias := "key_containing_" + string(tc.testChar) + "_character"
-		secretSpecs := []SecretSpec{{Alias: alias, Path: validConjurPath}}
+		secretSpecs := []filetemplates.SecretSpec{{Alias: alias, Path: validConjurPath}}
 
 		// Run test case
 		_, err := FileTemplateForFormat(fileFormat, secretSpecs)
@@ -123,7 +124,7 @@ func (tc *aliasLenTestCase) Run(t *testing.T, fileFormat string) {
 	t.Run(tc.description, func(t *testing.T) {
 		// Set up test case
 		desc := fmt.Sprintf("%s file format, %s", fileFormat, tc.description)
-		secretSpecs := []SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
+		secretSpecs := []filetemplates.SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
 
 		// Run test case
 		_, err := FileTemplateForFormat(fileFormat, secretSpecs)
@@ -259,7 +260,7 @@ func TestValidateAliasForProperties(t *testing.T) {
 	for _, tc := range testCases {
 		// Set up test case
 		desc := fmt.Sprintf("%s file format, alias with %s", "properties", tc.description)
-		secretSpecs := []SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
+		secretSpecs := []filetemplates.SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
 
 		// Run test case
 		_, err := FileTemplateForFormat("properties", secretSpecs)
@@ -303,7 +304,7 @@ func testValidateAliasForBashOrDotenv(t *testing.T, fileFormat string) {
 		// Set up test case
 		desc := fmt.Sprintf("%s file format, alias with %s",
 			fileFormat, tc.description)
-		secretSpecs := []SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
+		secretSpecs := []filetemplates.SecretSpec{{Alias: tc.alias, Path: validConjurPath}}
 
 		// Run test case
 		_, err := FileTemplateForFormat(fileFormat, secretSpecs)


### PR DESCRIPTION
### Desired Outcome

File templates can be used the same way for k8s_secrets as it is used in push-to-file configuration. Templates in secret annotation are rendered and store in target k8s secret. The Secret key can then be mounted as a file into the container's filesystem.

### Implemented Changes

Template processing functionality has been refactored - common code has been extracted from the pushtofile package into a new shared package. This allows template processing to be used in both scenarios: when processing file templates in the k8s_secrets target mode and push-to-file mode. When target secret is processed, both conjur-map and temaplates/groups are processed and rendered.

### Connected Issue/Story

DRAFT for:

https://github.com/cyberark/secrets-provider-for-k8s/issues/549